### PR TITLE
支持更多类型的文件上传

### DIFF
--- a/components/Chat.vue
+++ b/components/Chat.vue
@@ -105,7 +105,7 @@ const onSend = async () => {
   });
 
   const body = JSON.stringify({
-    knowledgebaseId: props.knowledgebase.id,
+    knowledgebaseId: props.knowledgebase?.id,
     model: model.value,
     messages: [...messages.value],
     stream: true,

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@types/ws": "^8.5.10",
+    "h3": "^1.11.1",
     "nuxt": "^3.10.0",
     "vue": "^3.4.15",
     "vue-router": "^4.2.5"

--- a/pages/knowledgebases/index.vue
+++ b/pages/knowledgebases/index.vue
@@ -98,7 +98,7 @@ const knowlegeBases = computed(() => {
         </UFormGroup>
 
         <UFormGroup label="File as Knowledge Base" name="file">
-          <UInput multiple type="file" size="sm" v-model="state.selectedFile" @change="onFileChange" />
+          <UInput multiple type="file" size="sm" accept=".txt,.json,.md,.doc,.docx,.pdf" v-model="state.selectedFile" @change="onFileChange" />
         </UFormGroup>
 
         <UButton type="submit" :loading="loading">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ devDependencies:
   '@types/ws':
     specifier: ^8.5.10
     version: 8.5.10
+  h3:
+    specifier: ^1.11.1
+    version: 1.11.1
   nuxt:
     specifier: ^3.10.0
     version: 3.10.0(vite@5.0.12)
@@ -1612,6 +1615,7 @@ packages:
       - sortablejs
       - supports-color
       - ts-node
+      - uWebSockets.js
       - universal-cookie
       - vite
       - vue
@@ -1638,7 +1642,7 @@ packages:
       externality: 1.0.2
       fs-extra: 11.2.0
       get-port-please: 3.1.2
-      h3: 1.10.1
+      h3: 1.11.1
       knitwork: 1.0.0
       magic-string: 0.30.6
       mlly: 1.5.0
@@ -1673,6 +1677,7 @@ packages:
       - supports-color
       - terser
       - typescript
+      - uWebSockets.js
       - vls
       - vti
       - vue-tsc
@@ -1698,7 +1703,7 @@ packages:
       colorette: 2.0.20
       consola: 3.2.3
       defu: 6.1.4
-      h3: 1.10.1
+      h3: 1.11.1
       micromatch: 4.0.5
       pathe: 1.1.2
       postcss: 8.4.33
@@ -1711,6 +1716,7 @@ packages:
       - rollup
       - supports-color
       - ts-node
+      - uWebSockets.js
     dev: false
 
   /@parcel/watcher-android-arm64@2.4.0:
@@ -3250,6 +3256,14 @@ packages:
   /crossws@0.1.1:
     resolution: {integrity: sha512-c9c/o7bS3OjsdpSkvexpka0JNlesBF2JU9B2V1yNsYGwRbAafxhJQ7VI9b48D5bpONz/oxbPGMzBojy9sXoQIQ==}
 
+  /crossws@0.2.4:
+    resolution: {integrity: sha512-DAxroI2uSOgUKLz00NX6A8U/8EE3SZHmIND+10jkVSaypvyt57J5JEOxAQOL6lQxyzi/wZbTIwssU1uy69h5Vg==}
+    peerDependencies:
+      uWebSockets.js: '*'
+    peerDependenciesMeta:
+      uWebSockets.js:
+        optional: true
+
   /crypt@0.0.2:
     resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
     dev: false
@@ -3453,6 +3467,9 @@ packages:
 
   /destr@2.0.2:
     resolution: {integrity: sha512-65AlobnZMiCET00KaFFjUefxDX0khFA/E4myqZ7a6Sq1yZtR8+FVIvilVX66vF2uobSumxooYZChiRPCKNqhmg==}
+
+  /destr@2.0.3:
+    resolution: {integrity: sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ==}
 
   /destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
@@ -3991,18 +4008,21 @@ packages:
     dependencies:
       duplexer: 0.1.2
 
-  /h3@1.10.1:
-    resolution: {integrity: sha512-UBAUp47hmm4BB5/njB4LrEa9gpuvZj4/Qf/ynSMzO6Ku2RXaouxEfiG2E2IFnv6fxbhAkzjasDxmo6DFdEeXRg==}
+  /h3@1.11.1:
+    resolution: {integrity: sha512-AbaH6IDnZN6nmbnJOH72y3c5Wwh9P97soSVdGSBbcDACRdkC0FEWf25pzx4f/NuOCK6quHmW18yF2Wx+G4Zi1A==}
     dependencies:
       cookie-es: 1.0.0
+      crossws: 0.2.4
       defu: 6.1.4
-      destr: 2.0.2
+      destr: 2.0.3
       iron-webcrypto: 1.0.0
       ohash: 1.1.3
       radix3: 1.1.0
-      ufo: 1.3.2
+      ufo: 1.4.0
       uncrypto: 0.1.3
       unenv: 1.9.0
+    transitivePeerDependencies:
+      - uWebSockets.js
 
   /has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
@@ -4823,7 +4843,7 @@ packages:
       crossws: 0.1.1
       defu: 6.1.4
       get-port-please: 3.1.2
-      h3: 1.10.1
+      h3: 1.11.1
       http-shutdown: 1.2.2
       jiti: 1.21.0
       mlly: 1.5.0
@@ -4833,6 +4853,8 @@ packages:
       ufo: 1.3.2
       untun: 0.1.3
       uqr: 0.1.2
+    transitivePeerDependencies:
+      - uWebSockets.js
 
   /local-pkg@0.4.3:
     resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
@@ -5316,7 +5338,7 @@ packages:
       fs-extra: 11.2.0
       globby: 14.0.0
       gzip-size: 7.0.0
-      h3: 1.10.1
+      h3: 1.11.1
       hookable: 5.5.3
       httpxy: 0.1.5
       is-primitive: 3.0.1
@@ -5365,6 +5387,7 @@ packages:
       - encoding
       - idb-keyval
       - supports-color
+      - uWebSockets.js
 
   /node-addon-api@7.1.0:
     resolution: {integrity: sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==}
@@ -5595,7 +5618,7 @@ packages:
       estree-walker: 3.0.3
       fs-extra: 11.2.0
       globby: 14.0.0
-      h3: 1.10.1
+      h3: 1.11.1
       hookable: 5.5.3
       jiti: 1.21.0
       klona: 2.0.6
@@ -5656,6 +5679,7 @@ packages:
       - supports-color
       - terser
       - typescript
+      - uWebSockets.js
       - utf-8-validate
       - vite
       - vls
@@ -7189,6 +7213,9 @@ packages:
   /ufo@1.3.2:
     resolution: {integrity: sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==}
 
+  /ufo@1.4.0:
+    resolution: {integrity: sha512-Hhy+BhRBleFjpJ2vchUNN40qgkh0366FWJGqVLYBHev0vpHTrXSA0ryT+74UiW6KWsldNurQMKGqCm1M2zBciQ==}
+
   /ultrahtml@1.5.2:
     resolution: {integrity: sha512-qh4mBffhlkiXwDAOxvSGxhL0QEQsTbnP9BozOK3OYPEGvPvdWzvAUaXNtUSMdNsKDtuyjEbyVUPFZ52SSLhLqw==}
 
@@ -7346,7 +7373,7 @@ packages:
       anymatch: 3.1.3
       chokidar: 3.5.3
       destr: 2.0.2
-      h3: 1.10.1
+      h3: 1.11.1
       ioredis: 5.3.2
       listhen: 1.6.0
       lru-cache: 10.2.0
@@ -7356,6 +7383,7 @@ packages:
       ufo: 1.3.2
     transitivePeerDependencies:
       - supports-color
+      - uWebSockets.js
 
   /untun@0.1.3:
     resolution: {integrity: sha512-4luGP9LMYszMRZwsvyUd9MrxgEGZdZuZgpVQHEEX0lCYFESasVRvZd0EYpCkOIbJKHMuv0LskpXc/8Un+MJzEQ==}

--- a/server/api/knowledgebases/index.post.ts
+++ b/server/api/knowledgebases/index.post.ts
@@ -1,25 +1,15 @@
-import path from 'node:path'
-import fs from 'node:fs/promises'
 import { PDFLoader } from "langchain/document_loaders/fs/pdf";
+import { TextLoader } from "langchain/document_loaders/fs/text";
+import { JSONLoader } from "langchain/document_loaders/fs/json";
+import { DocxLoader } from "langchain/document_loaders/fs/docx";
 import { RecursiveCharacterTextSplitter } from "langchain/text_splitter";
 import { OllamaEmbeddings } from "@langchain/community/embeddings/ollama";
 import { Chroma } from "@langchain/community/vectorstores/chroma";
 import { PrismaClient } from '@prisma/client';
+import { MultiPartData } from 'h3'
 
-const ingestDocument = async (file, collectionName, embedding) => {
-  const tmpDir = path.resolve('tmp');
-  try {
-    await fs.access(tmpDir);
-  } catch (error) {
-    await fs.mkdir(tmpDir);
-  }
-  const tmp_file_path = path.join(tmpDir, file.filename);
-
-  const status = await fs.writeFile(tmp_file_path, file.data)
-  console.log(`Writing data to file ${tmp_file_path}: ${status}`);
-
-  const loader = new PDFLoader(tmp_file_path);
-  const docs = await loader.load();
+const ingestDocument = async (file: MultiPartData, collectionName: string, embedding: string) => {
+  const docs = await loadDocuments(file)
 
   const textSplitter = new RecursiveCharacterTextSplitter({ chunkSize: 1000, chunkOverlap: 200 });
   const splits = await textSplitter.splitDocuments(docs);
@@ -42,38 +32,68 @@ const ingestDocument = async (file, collectionName, embedding) => {
   }
 }
 
+async function loadDocuments(file: MultiPartData) {
+  const Loaders = {
+    pdf: PDFLoader,
+    json: JSONLoader,
+    docx: DocxLoader,
+    doc: DocxLoader,
+    txt: TextLoader,
+    md: TextLoader,
+  } as const;
+
+  const ext = (file.filename?.match(/\.(\w+)$/)?.[1] || 'txt').toLowerCase() as keyof typeof Loaders;
+  if (!Loaders[ext]) {
+    throw new Error(`Unsupported file type: ${ext}`);
+  }
+  const blob = new Blob([file.data], { type: file.type })
+  return new Loaders[ext](blob).load();
+}
+
 export default defineEventHandler(async (event) => {
   const items = await readMultipartFormData(event);
 
-  const knowledgeBase: { [key: string]: string | Date } = {};
   const decoder = new TextDecoder("utf-8");
-  const uploadedFiles = [];
+  const uploadedFiles: MultiPartData[] = [];
+
+  let _name = ''
+  let _description = ''
+  let _embedding = ''
   items?.forEach((item) => {
-    const { name, data, filename } = item;
-    if (name) {
-      if (name.startsWith("file_")) {
-        uploadedFiles.push(item);
-      }
-      if (["name", "description", "embedding"].includes(name)) {
-        knowledgeBase[name] = decoder.decode(data);
-      }
+    const key = item.name || '';
+    const decodeData = decoder.decode(item.data)
+    if (key.startsWith("file_")) {
+      uploadedFiles.push(item);
+    }
+    if (key === 'name') {
+      _name = decodeData
+    }
+    if (key === 'description') {
+      _description = decodeData
+    }
+    if (key === 'embedding') {
+      _embedding = decodeData
     }
   });
 
   const prisma = new PrismaClient();
-  knowledgeBase.created = new Date();
   const affected = await prisma.knowledgeBase.create({
-    data: knowledgeBase
+    data: {
+      name: _name,
+      description: _description,
+      embedding: _embedding,
+      created: new Date(),
+    }
   });
-  console.log(`Created knowledge base ${knowledgeBase.name}: ${affected}`);
+  console.log(`Created knowledge base ${_name}: ${affected}`);
 
   if (uploadedFiles.length > 0) {
     for (const uploadedFile of uploadedFiles) {
-      await ingestDocument(uploadedFile, `collection_${affected.id}`, affected.embedding);
+      await ingestDocument(uploadedFile, `collection_${affected.id}`, affected.embedding!);
 
       const createdKnowledgeBaseFile = await prisma.knowledgeBaseFile.create({
         data: {
-          url: uploadedFile.filename,
+          url: uploadedFile.filename!,
           knowledgeBaseId: affected.id
         }
       });


### PR DESCRIPTION
感觉我对这个项目有点上头了，又搞了点事情😂

- Chat 页面添加容错处理
- 支持 .txt,.json,.md,.doc,.docx,.pdf 格式文件的上传
- 重构文件的内容的读取，直接将文件的 Buffer 转 Blob，不需要再将文件存储本地