### PR TITLE
fix: replace localhost with 127.0.0.1

### DIFF
--- a/server/middleware/ollama.ts
+++ b/server/middleware/ollama.ts
@@ -1,6 +1,6 @@
 export default defineEventHandler((event) => {
   const headers = getRequestHeaders(event);
-  const host = (headers['x_ollama_host'] || 'http://localhost:11434').replace(/\/$/, '');
+  const host = (headers['x_ollama_host'] || 'http://127.0.0.1:11434').replace(/\/$/, '');
   const username = headers['x_ollama_username'] || null;
   const password = headers['x_ollama_password'] || null;
 


### PR DESCRIPTION
如果 localhost 不能成功指向到 127.0.0.1 就会报下面的错误，所以默认直接用 127.0.0.1，关联问题 #52 

```
[nuxt] [request error] [unhandled] [500] fetch failed
  at Object.fetch (node:internal/deps/undici/undici:11372:11)  
  at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```