### PR TITLE
支持手动停止内容输出功能

### DIFF
--- a/assets/index.scss
+++ b/assets/index.scss
@@ -1,7 +1,7 @@
 @import 'highlight.js/scss/github.scss';
 
 pre code.hljs {
-  background-color: #f8fafc;
+  background-color: #f4f4f4;
   border-radius: 8px;
   margin: 0.5em 0;
 }

--- a/components/Chat.vue
+++ b/components/Chat.vue
@@ -35,8 +35,9 @@ const selectedInstruction = ref<Awaited<ReturnType<typeof loadOllamaInstructions
 const chatInputBoxRef = shallowRef()
 
 const model = useStorage(`model${props.knowledgebase?.id || ''}`, null);
-const messages = ref<Array<{ role: 'system' | 'assistant' | 'user', content: string }>>([]);
+const messages = ref<Array<{ role: 'system' | 'assistant' | 'user', content: string, type?: 'loading' | 'canceled' }>>([]);
 const sending = ref(false);
+let abortHandler: (() => void) | null = null;
 
 const visibleMessages = computed(() => {
   return messages.value.filter((message) => message.role !== 'system');
@@ -50,6 +51,7 @@ const fetchStream = async (url: string, options: RequestInit) => {
   const response = await fetch(url, options);
 
   if (response.body) {
+    messages.value = messages.value.filter((message) => message.type !== 'loading');
     const reader = response.body.getReader();
     while (true) {
       const { done, value } = await reader.read();
@@ -101,12 +103,20 @@ const onSend = async (data: ChatBoxFormData) => {
     content: input
   });
 
+  messages.value.push({
+    role: "assistant",
+    content: "",
+    type: 'loading'
+  })
+
   const body = JSON.stringify({
     knowledgebaseId: props.knowledgebase?.id,
     model: model.value,
     messages: [...messages.value],
     stream: true,
   })
+  const controller = new AbortController();
+  abortHandler = () => controller.abort();
   await fetchStream('/api/models/chat', {
     method: 'POST',
     body: body,
@@ -115,6 +125,7 @@ const onSend = async (data: ChatBoxFormData) => {
       ...fetchHeadersThirdApi.value,
       'Content-Type': 'application/json',
     },
+    signal: controller.signal,
   });
 
   sending.value = false;
@@ -139,6 +150,18 @@ useMutationObserver(messageListEl, () => {
   });
 }, { childList: true, subtree: true });
 
+function onAbortChat() {
+  abortHandler?.()
+  if (messages.value.length > 0) {
+    const lastOne = messages.value[messages.value.length - 1];
+    if (lastOne.type === 'loading') {
+      messages.value.pop();
+    } else if (lastOne.role === 'assistant') {
+      lastOne.type = 'canceled';
+    }
+  }
+  sending.value = false
+}
 </script>
 
 <template>
@@ -160,16 +183,19 @@ useMutationObserver(messageListEl, () => {
     <div ref="messageListEl" class="relative flex-1 overflow-auto px-4">
       <div v-for="(message, index) in visibleMessages" :key="index" :class="{ 'text-right': message.role === 'user' }">
         <div class="text-gray-500 dark:text-gray-400">{{ message.role }}</div>
-        <div class="mb-4">
+        <div class="mb-4 leading-6" :class="{ 'text-gray-400 dark:text-gray-500': message.type === 'canceled' }">
           <div
-            :class="`inline-flex ${message.role == 'assistant' ? 'bg-white/10' : 'bg-primary-50 dark:bg-primary-400/20'} border border-primary/20 rounded-lg px-3 py-2`">
-            <div v-html="markdown.render(message.content)" />
+            :class="`inline-flex ${message.role == 'assistant' ? 'bg-gray-50 dark:bg-gray-800' : 'bg-primary-50 dark:bg-primary-400/60'} border border-primary/20 rounded-lg px-3 py-2`">
+            <div v-if="message.type === 'loading'"
+              class="text-xl text-primary animate-spin i-heroicons-arrow-path-solid">
+            </div>
+            <div v-else v-html="markdown.render(message.content)" />
           </div>
         </div>
       </div>
     </div>
     <div class="shrink-0 pt-4 px-4">
-      <ChatInputBox ref="chatInputBoxRef" :disabled="!model" :loading="sending" @submit="onSend" />
+      <ChatInputBox ref="chatInputBoxRef" :disabled="!model" :loading="sending" @submit="onSend" @stop="onAbortChat" />
     </div>
   </div>
 </template>

--- a/components/ChatInputBox.vue
+++ b/components/ChatInputBox.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
 
 const emits = defineEmits<{
   submit: [data: ChatBoxFormData]
+  stop: []
 }>()
 
 const submitMode = useStorage<SubmitMode>('sendMode', 'enter')
@@ -20,7 +21,8 @@ const state = reactive<ChatBoxFormData>({
   content: '',
 })
 const tip = computed(() => {
-  return sendModeList[0].find(el => el.value === submitMode.value)?.label
+  const s = sendModeList[0].find(el => el.value === submitMode.value)?.label || ''
+  return `(${s})`
 })
 const isFocus = ref(false)
 const sendModeList = [
@@ -30,7 +32,7 @@ const sendModeList = [
   ]
 ] as const
 const disabledBtn = computed(() => {
-  return props.disabled || !state.content.trim()
+  return props.disabled || (!props.loading && !state.content.trim())
 })
 
 defineExpose({
@@ -45,6 +47,13 @@ function onSubmit() {
   if (props.disabled) return
 
   emits('submit', { ...state })
+}
+
+function onStop(e: Event) {
+  if (props.loading) {
+    e.preventDefault()
+    emits('stop')
+  }
 }
 
 function onReset() {
@@ -63,10 +72,9 @@ function onReset() {
       <div class="flex">
         <div class="flex items-center ml-auto">
           <ClientOnly>
-            <UButton type="submit" :disabled="disabledBtn" class="send-btn" icon="i-iconoir-send-diagonal"
-              :loading="loading" loading-icon="i-iconoir-lens">
-              <span class="text-xs tip-text" v-show="!loading">({{
-      tip }})</span>
+            <UButton type="submit" :disabled="disabledBtn" class="send-btn"
+              :icon="loading ? 'i-iconoir-square' : 'i-iconoir-send-diagonal'" @click="onStop">
+              <span class="text-xs tip-text">{{ loading ? ' Stop' : tip }}</span>
             </UButton>
             <UDropdown :items="sendModeList" :popper="{ placement: 'top-end' }">
               <UButton trailing-icon="i-heroicons-chevron-down-20-solid" class="arrow-btn" />

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@nuxtjs/google-fonts": "^3.2.0",
+    "@types/markdown-it": "^13.0.7",
     "@types/node": "^20.11.28",
     "@types/ws": "^8.5.10",
     "h3": "^1.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ devDependencies:
   '@nuxtjs/google-fonts':
     specifier: ^3.2.0
     version: 3.2.0
+  '@types/markdown-it':
+    specifier: ^13.0.7
+    version: 13.0.7
   '@types/node':
     specifier: ^20.11.28
     version: 20.11.28
@@ -2603,18 +2606,15 @@ packages:
 
   /@types/linkify-it@3.0.5:
     resolution: {integrity: sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==}
-    dev: false
 
   /@types/markdown-it@13.0.7:
     resolution: {integrity: sha512-U/CBi2YUUcTHBt5tjO2r5QV/x0Po6nsYwQU4Y04fBS6vfoImaiZ6f8bi3CjTCxBPQSO1LMyUqkByzi8AidyxfA==}
     dependencies:
       '@types/linkify-it': 3.0.5
       '@types/mdurl': 1.0.5
-    dev: false
 
   /@types/mdurl@1.0.5:
     resolution: {integrity: sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==}
-    dev: false
 
   /@types/node-fetch@2.6.11:
     resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}

--- a/types/markdown-it.d.ts
+++ b/types/markdown-it.d.ts
@@ -1,0 +1,5 @@
+declare module 'markdown-it-abbr';
+declare module 'markdown-it-footnote';
+declare module 'markdown-it-sub';
+declare module 'markdown-it-sup';
+declare module 'markdown-it-task-lists';

--- a/utils/settings.ts
+++ b/utils/settings.ts
@@ -62,9 +62,7 @@ export const fetchHeadersThirdApi = computed(() => {
 
 export const loadOllamaInstructions = async () => {
   try {
-    const { instructions } = (await $fetch(`/api/instruction/`, {
-      method: "GET",
-    })) as Record<string, any>;
+    const { instructions } = await $fetch<Record<string, { id: number, name: string, instruction: string }[]>>(`/api/instruction/`);
     return instructions;
   } catch (e) {
     console.error("Failed to fetch Ollama instructions", e);


### PR DESCRIPTION
- Chat.vue 文件使用 ts 重构，并且样式做了轻微调整
-  #118

@sugarforever 前端已经实现了取消请求功能

现在发现的问题是在前端取消请求后再发消息需要等待很久，感觉是要等上个内容生成结束才会继续下一个，所以我感觉后端也需要取消 Ollama 的输出，但我没有找到相关的 API，需要你帮忙看看。

![图片](https://github.com/sugarforever/chat-ollama/assets/5283258/6dd2b486-bef6-448e-9888-d6316df9c949)
