### PR TITLE
assistant loading type message got sent along with other messages

### DIFF
--- a/components/Chat.vue
+++ b/components/Chat.vue
@@ -112,7 +112,7 @@ const onSend = async (data: ChatBoxFormData) => {
   const body = JSON.stringify({
     knowledgebaseId: props.knowledgebase?.id,
     model: model.value,
-    messages: [...messages.value],
+    messages: [...messages.value.filter(m => m.type !== 'loading')],
     stream: true,
   })
   const controller = new AbortController();

--- a/server/api/models/chat/index.post.ts
+++ b/server/api/models/chat/index.post.ts
@@ -87,14 +87,16 @@ export default defineEventHandler(async (event) => {
     console.log(response);
     const readableStream = Readable.from((async function* () {
       for await (const chunk of response) {
-        const message = {
-          message: {
-            role: 'assistant',
-            content: chunk?.answer
-          }
-        };
-        console.log(message);
-        yield `${JSON.stringify(message)}\n\n`;
+        if (chunk?.answer !== undefined) {
+          const message = {
+            message: {
+              role: 'assistant',
+              content: chunk?.answer
+            }
+          };
+          console.log(message);
+          yield `${JSON.stringify(message)}\n\n`;
+        }
       }
     })());
     return sendStream(event, readableStream);


### PR DESCRIPTION
In the front end, `loading` type message is used to render the loading status while waiting for server response.

But such type of message  along with other messages got sent as chat history. It broke the chat feature at the server side.

In this PR, the loading type message is filtered out to make sure the user's query is always the latest one in the chat history.