### PR TITLE
fix: failed to update knowledgebases when urls is empty

### DIFF
--- a/components/KnowledgeBaseUpdateForm.vue
+++ b/components/KnowledgeBaseUpdateForm.vue
@@ -22,10 +22,12 @@ const loading = ref(false)
 const onSubmit = async () => {
   loading.value = true
   const formData = new FormData()
-  state.urls
-    .split(' ')
-    .map((url: string) => url.trim())
-    .forEach((url: string) => formData.append('urls', url))
+  if (state.urls.trim().length > 0) {
+    state.urls
+      .split(' ')
+      .map((url: string) => url.trim())
+      .forEach((url: string) => formData.append('urls', url))
+  }
 
   Array.from(selectedFiles.value).forEach((file, index) => {
     console.log(`Index ${index}`, file)


### PR DESCRIPTION
The problem is not completely resolved. When a new knowledge base has a URL, or when knowledge is modified (even if there is no URL), there are still the same errors, but adding or modifying the PDF to the knowledge base is successful.

_Originally posted by @Rock1965 in https://github.com/sugarforever/chat-ollama/issues/221#issuecomment-2041456584_
            