### PR TITLE
feat: nitro powered openapi endpoint

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -21,6 +21,11 @@ export default defineNuxtConfig({
       }
     }]
   ],
+  nitro: {
+    experimental: {
+      openAPI: true
+    }
+  },
   ui: {
     icons: ['heroicons', 'iconoir', 'material-symbols', 'mdi']
   },


### PR DESCRIPTION
ChatOllama needs a type of APIs documentation so that developers can use the endpoints as needed.

Nitro, the underlying infra of Nuxt has the experimental feature to support OpenAPI compatible API doc:
https://nitro.unjs.io/config#experimental

Notice that, the current doc `http://localhost:3000/_nitro/openapi.json` has not enough API schema information, for example the payload schema of `/v1/models/chat`.

It will be improved in the future. Let's use this PR to expose the base API documentation for now.