### PR TITLE
refactor: refactor embedding input UX

### DIFF
--- a/components/KnowledgeBaseForm.vue
+++ b/components/KnowledgeBaseForm.vue
@@ -37,7 +37,6 @@ const embeddingList = computed(() => {
   })
 })
 const formRef = shallowRef()
-const embeddingInputRef = shallowRef()
 const showEmbeddingDropdown = ref(false)
 const parserList = [
   { label: 'Cheerio', value: 'cheerio' },
@@ -148,7 +147,7 @@ function generateEmbeddingData(groupName: string, list: string[], slotName: stri
                 <div>{{ item.label }}</div>
               </template>
             </UDropdown>
-            <UInput ref="embeddingInputRef" v-model="state.embedding" class="grow" autocomplete="off" @focus="showEmbeddingDropdown = true" />
+            <UInput v-model="state.embedding" class="grow" autocomplete="off" placeholder="Input or select an embedding" @focus="showEmbeddingDropdown = true" />
           </div>
         </UFormGroup>
 

--- a/pages/knowledgebases/index.vue
+++ b/pages/knowledgebases/index.vue
@@ -20,6 +20,7 @@ const columns = [
 ]
 
 const knowledgeBases = computed(() => data.value?.knowledgeBases || [])
+const embeddings = computed(() => [...new Set(data.value?.knowledgeBases?.flatMap(el => el.embedding || []) || [])])
 
 async function onStartChat(data: KnowledgeBase) {
   const chatSessionInfo = await createChatSession({ title: data.name, knowledgeBaseId: data.id })
@@ -45,6 +46,7 @@ function onShowCreate() {
   modal.open(KnowledgeBaseForm, {
     type: 'create',
     title: 'Create a New Knowledge Base',
+    embeddings: embeddings.value,
     onClose: () => modal.close(),
     onSuccess: () => refresh()
   })
@@ -55,6 +57,7 @@ function onShowUpdate(data: KnowledgeBase) {
     type: 'update',
     title: 'Update Knowledge Base',
     data,
+    embeddings: embeddings.value,
     onClose: () => modal.close(),
     onSuccess: () => refresh()
   })


### PR DESCRIPTION
重构文本嵌入模型输入框的操作交互，其中 Ollama 的文本嵌入模型来自于知识库列表中的 embedding 字段

![图片](https://github.com/sugarforever/chat-ollama/assets/5283258/e05efbaf-c8da-4f2f-afad-1194144d8844)

关联 #286 