### PR TITLE
Abitclose/fix 0419

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,8 @@ VECTOR_STORE=chroma
 CHROMADB_URL=http://localhost:8000
 MILVUS_URL=http://localhost:19530
 
+# Default ollama host , the use priorities are client http header 'x_ollama_host' , env.OLLAMA_HOST, and http://127.0.0.1:11434
+OLLAMA_HOST=http://localhost:11434
+
 # Cohere API Key - Reranking
 COHERE_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ chroma_data
 
 .DS_Store
 yarn.lock
+
+
+.idea

--- a/server/api/knowledgebases/index.post.ts
+++ b/server/api/knowledgebases/index.post.ts
@@ -59,17 +59,26 @@ export default defineEventHandler(async (event) => {
       console.log("KnowledgeBaseFile with ID: ", createdKnowledgeBaseFile.id)
     }
 
-    await ingestURLs(urls, `collection_${affected.id}`, affected.embedding!, event)
-    for (const url of urls) {
-      const createdKnowledgeBaseFile = await prisma.knowledgeBaseFile.create({
-        data: {
-          url: url,
-          knowledgeBaseId: affected.id
-        }
-      })
+    if (urls.length > 0) {
+      await ingestURLs(urls, `collection_${affected.id}`, affected.embedding!, event)
+      for (const url of urls) {
 
-      console.log("Knowledge base file created with ID: ", createdKnowledgeBaseFile.id)
+        if (!url) {
+          console.log(`No URL detected, processing is skipped`)
+          continue
+        }
+
+        const createdKnowledgeBaseFile = await prisma.knowledgeBaseFile.create({
+          data: {
+            url: url,
+            knowledgeBaseId: affected.id
+          }
+        })
+
+        console.log("Knowledge base file created with ID: ", createdKnowledgeBaseFile.id)
+      }
     }
+
   } catch (e) {
     await prisma.knowledgeBase.delete({
       where: {

--- a/server/middleware/ollama.ts
+++ b/server/middleware/ollama.ts
@@ -1,9 +1,23 @@
 export default defineEventHandler((event) => {
-  const headers = getRequestHeaders(event);
-  const host = (headers['x_ollama_host'] || 'http://127.0.0.1:11434').replace(/\/$/, '');
-  const username = headers['x_ollama_username'] || null;
-  const password = headers['x_ollama_password'] || null;
 
-  console.log("Ollama: ", { host, username, password });
+  const headers = getRequestHeaders(event)
+
+  let ollamaServer: any = headers['x_ollama_host']
+
+  console.log(`Ollama Server : ${ollamaServer}`)
+
+  if (!headers['x_ollama_host']) {
+    ollamaServer = process.env.OLLAMA_HOST
+  }
+
+  if (!ollamaServer) {
+    ollamaServer = 'http://127.0.0.1:11434'
+  }
+
+  const host = ollamaServer.replace(/\/$/, '')
+  const username = headers['x_ollama_username'] || null
+  const password = headers['x_ollama_password'] || null
+
+  console.log("Ollama: ", { host, username, password })
   event.context.ollama = { host, username, password }
 })


### PR DESCRIPTION
1、Sometimes the server cannot correctly obtain the http header of x_ollama_host, so server\middleware\ollama.ts is modified to make ollama interface configuration compatible and optimized.
2、Modified the .env.example file and added an optional environment variable OLLAMA_HOST