### PR TITLE
feat: add configurable parameters for webpage scraping

### DIFF
--- a/composables/utils.ts
+++ b/composables/utils.ts
@@ -1,3 +1,8 @@
 export function noop() {
   // do nothing
 }
+
+export function urlGlob2Regexp(pattern: string) {
+  const s = pattern.replace(/([.?+^$[\]\\(){}|\/-])/g, "\\$1").replace(/(?<!\\)\*/, '.*')
+  return new RegExp(s)
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   },
   "devDependencies": {
     "@nuxtjs/google-fonts": "^3.2.0",
+    "@types/html-to-text": "^9.0.4",
+    "@types/jsdom": "^21.1.6",
     "@types/markdown-it": "^13.0.7",
     "@types/node": "^20.12.5",
     "@types/ws": "^8.5.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,12 @@ devDependencies:
   '@nuxtjs/google-fonts':
     specifier: ^3.2.0
     version: 3.2.0
+  '@types/html-to-text':
+    specifier: ^9.0.4
+    version: 9.0.4
+  '@types/jsdom':
+    specifier: ^21.1.6
+    version: 21.1.6
   '@types/markdown-it':
     specifier: ^13.0.7
     version: 13.0.7
@@ -2943,10 +2949,22 @@ packages:
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
+  /@types/html-to-text@9.0.4:
+    resolution: {integrity: sha512-pUY3cKH/Nm2yYrEmDlPR1mR7yszjGx4DrwPjQ702C4/D5CwHuZTgZdIdwPkRbcuhs7BAh2L5rg3CL5cbRiGTCQ==}
+    dev: true
+
   /@types/http-proxy@1.17.14:
     resolution: {integrity: sha512-SSrD0c1OQzlFX7pGu1eXxSEjemej64aaNPRhhVYUGqXh0BtldAAx37MG8btcumvpgKyZp1F5Gn3JkktdxiFv6w==}
     dependencies:
       '@types/node': 20.12.5
+
+  /@types/jsdom@21.1.6:
+    resolution: {integrity: sha512-/7kkMsC+/kMs7gAYmmBR9P0vGTnOoLhQhyhQJSlXGI5bzTHp6xdo0TtKWQAsz6pmSAeVqKSbqeyP6hytqr9FDw==}
+    dependencies:
+      '@types/node': 20.12.5
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.1.2
+    dev: true
 
   /@types/linkify-it@3.0.5:
     resolution: {integrity: sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==}
@@ -2988,6 +3006,10 @@ packages:
   /@types/retry@0.12.0:
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
     dev: false
+
+  /@types/tough-cookie@4.0.5:
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+    dev: true
 
   /@types/triple-beam@1.3.5:
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
@@ -7480,7 +7502,6 @@ packages:
     resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
     dependencies:
       entities: 4.5.0
-    dev: false
 
   /parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}

--- a/server/api/knowledgebases/index.post.ts
+++ b/server/api/knowledgebases/index.post.ts
@@ -59,8 +59,8 @@ export default defineEventHandler(async (event) => {
       console.log("KnowledgeBaseFile with ID: ", createdKnowledgeBaseFile.id)
     }
 
-    await ingestURLs(urls, `collection_${affected.id}`, affected.embedding!, event)
-    for (const url of urls) {
+    const allUrls = await ingestURLs(urls, `collection_${affected.id}`, affected.embedding!, event)
+    for (const url of allUrls) {
       const createdKnowledgeBaseFile = await prisma.knowledgeBaseFile.create({
         data: {
           url: url,

--- a/server/types/index.ts
+++ b/server/types/index.ts
@@ -1,6 +1,6 @@
 import { MultiPartData } from 'h3'
 
-export type PageParser = 'cheerio' | 'jinaReader'
+export type PageParser = 'default' | 'jinaReader'
 
 export type KnowledgeBaseFormData = {
   name: string
@@ -10,4 +10,6 @@ export type KnowledgeBaseFormData = {
   uploadedFiles: MultiPartData[]
   urls: string[]
   pageParser: PageParser
+  maxDepth: number
+  excludeGlobs: string[]
 }

--- a/server/utils/rag.ts
+++ b/server/utils/rag.ts
@@ -3,12 +3,11 @@ import { PDFLoader } from "langchain/document_loaders/fs/pdf"
 import { TextLoader } from "langchain/document_loaders/fs/text"
 import { JSONLoader } from "langchain/document_loaders/fs/json"
 import { DocxLoader } from "langchain/document_loaders/fs/docx"
-import { CheerioWebBaseLoader } from "langchain/document_loaders/web/cheerio"
-import { RecursiveUrlLoader } from "langchain/document_loaders/web/recursive_url"
 import { compile } from "html-to-text"
 import { MultiPartData, H3Event } from 'h3'
 import { createRetriever } from '@/server/retriever'
 import type { PageParser } from '@/server/types'
+import { RecursiveUrlLoader, type RecursiveUrlLoaderOptions } from '@/server/utils/recursiveUrlLoader'
 
 export const loadDocuments = async (file: MultiPartData) => {
   const Loaders = {
@@ -28,35 +27,41 @@ export const loadDocuments = async (file: MultiPartData) => {
   return new Loaders[ext](blob).load()
 }
 
-export const loadURL = async (url: string, pageParser: PageParser) => {
-  console.log("URL: ", url)
-  if (pageParser === 'jinaReader') {
-    console.log("Using Jina reader to load URL")
-    const jinaUrl = `https://r.jina.ai/${url}`
-    const response = await fetch(jinaUrl)
-    const data = await response.text()
-    return [
-      new Document({
-        pageContent: data,
-        metadata: { source: url }
-      })
-    ]
-  } else {
-    /*console.log("Using CheerioWebBaseLoader to load URL")
-    const loader = new CheerioWebBaseLoader(url)
-    const docs = await loader.load()
-    console.log(`Documents loaded and parsed from ${url}:`, docs)*/
+interface LoadUrlOptions {
+  pageParser: PageParser
+  maxDepth?: number
+  excludeGlobs?: string[]
+}
 
-    const compiledConvert = compile({ wordwrap: 130 }) // returns (text: string) => string;
-
-    const loader = new RecursiveUrlLoader(url, {
-      extractor: compiledConvert,
-      maxDepth: 1
-    })
-
-    const docs = await loader.load()
-    return docs
+export const loadURL = async (url: string, options: LoadUrlOptions) => {
+  console.log('Entry URL:', url, options.pageParser)
+  let loaderOptions: RecursiveUrlLoaderOptions = {
+    maxDepth: options.maxDepth ?? 0,
+    callerOptions: {
+      maxRetries: 1,
+    },
+    timeout: 5000,
+    excludeGlobs: options.excludeGlobs ?? [],
   }
+
+  if (options.pageParser === 'jinaReader') {
+    loaderOptions.fetch = (url, options) => {
+      return fetch(`https://r.jina.ai/${url}`, options)
+    }
+    loaderOptions.extractMetadata = (text, url) => {
+      return {
+        source: url,
+        title: text.trim().match(/(?<=^Title: ).+/)?.[0] ?? ''
+      }
+    }
+  } else {
+    loaderOptions.extractor = compile({ wordwrap: 130 })
+  }
+
+  const loader = new RecursiveUrlLoader(url, loaderOptions)
+  const docs = await loader.load()
+
+  return docs
 }
 
 export const ingestDocument = async (
@@ -87,12 +92,16 @@ export const ingestURLs = async (
   embedding: string,
   event: H3Event
 ) => {
-  const docs = []
-  const { pageParser } = await parseKnowledgeBaseFormRequest(event)
+  const docs: Document[] = []
+  const entryAndChildUrls = new Set<string>()
+  const { pageParser, maxDepth, excludeGlobs } = await parseKnowledgeBaseFormRequest(event)
 
   for (const url of urls) {
-    const loadedDocs = await loadURL(url, pageParser)
-    docs.push(...loadedDocs)
+    const loadedDocs = await loadURL(url, { pageParser, maxDepth, excludeGlobs })
+    loadedDocs.forEach(doc => {
+      docs.push(doc)
+      entryAndChildUrls.add(doc.metadata.source.replace(/\/$/, ''))
+    })
   }
 
   const embeddings = createEmbeddings(embedding, event)
@@ -101,4 +110,8 @@ export const ingestURLs = async (
   await retriever.addDocuments(docs)
 
   console.log(`${docs.length} URLs added to collection ${collectionName}.`)
+
+  console.log('All URLs:', entryAndChildUrls)
+
+  return entryAndChildUrls
 }

--- a/server/utils/recursiveUrlLoader.ts
+++ b/server/utils/recursiveUrlLoader.ts
@@ -1,0 +1,237 @@
+// Copy from https://github.com/langchain-ai/langchainjs/blob/e1f21e6d6c7651800895c940cd6ace4f3a5325bc/langchain/src/document_loaders/web/recursive_url.ts
+
+import { JSDOM } from 'jsdom'
+import { Document } from '@langchain/core/documents'
+import { AsyncCaller } from '@langchain/core/utils/async_caller'
+import { BaseDocumentLoader, DocumentLoader } from 'langchain/document_loaders/base'
+import { urlGlob2Regexp } from '~/composables/utils'
+
+interface Metadata {
+  source: string,
+  title?: string
+  description?: string
+  language?: string
+}
+
+export interface RecursiveUrlLoaderOptions {
+  excludeDirs?: string[]
+  extractor?: (text: string) => string
+  extractMetadata?: (text: string, url: string) => Metadata
+  maxDepth?: number
+  timeout?: number
+  preventOutside?: boolean
+  callerOptions?: ConstructorParameters<typeof AsyncCaller>[0]
+  fetch?: typeof fetch
+  excludeGlobs?: string[]
+}
+
+export class RecursiveUrlLoader extends BaseDocumentLoader implements DocumentLoader {
+  private caller: AsyncCaller
+
+  private url: string
+
+  private excludeDirs: string[]
+
+  private extractor: (text: string) => string
+
+  private extractMetadata: Required<RecursiveUrlLoaderOptions>['extractMetadata']
+
+  private maxDepth: number
+
+  private timeout: number
+
+  private preventOutside: boolean
+
+  private fetch: RecursiveUrlLoaderOptions['fetch']
+
+  private excludeGlobs: RegExp[]
+
+  constructor(url: string, options: RecursiveUrlLoaderOptions) {
+    super()
+
+    this.caller = new AsyncCaller({
+      maxConcurrency: 64,
+      maxRetries: 0,
+      ...options.callerOptions,
+    })
+
+    this.url = url
+    this.excludeDirs = options.excludeDirs ?? []
+    this.extractor = options.extractor ?? ((s: string) => s)
+    this.extractMetadata = options.extractMetadata ?? this.extractMetadataFn
+    this.maxDepth = options.maxDepth ?? 2
+    this.timeout = options.timeout ?? 10000
+    this.preventOutside = options.preventOutside ?? true
+    this.fetch = options.fetch
+    this.excludeGlobs = options.excludeGlobs?.map(s => urlGlob2Regexp(s)) || []
+  }
+
+  private async fetchWithTimeout(
+    resource: string,
+    options: { timeout: number } & RequestInit,
+    isGetChildLinks = false
+  ): Promise<Response> {
+    const { timeout, ...rest } = options
+    return this.caller.call(() =>
+      this.fetch && !isGetChildLinks
+        ? this.fetch(resource, { ...rest, signal: AbortSignal.timeout(timeout) })
+        : fetch(resource, { ...rest, signal: AbortSignal.timeout(timeout) })
+    )
+  }
+
+  private getChildLinks(html: string, baseUrl: string): Array<string> {
+    const allLinks = Array.from(
+      new JSDOM(html).window.document.querySelectorAll('a')
+    ).map((a) => a.href)
+    const absolutePaths = []
+    // eslint-disable-next-line no-script-url
+    const invalidPrefixes = ['javascript:', 'mailto:', '#']
+    const invalidSuffixes = [
+      '.css',
+      '.js',
+      '.ico',
+      '.png',
+      '.jpg',
+      '.jpeg',
+      '.gif',
+      '.svg',
+    ]
+
+    for (const link of allLinks) {
+      if (
+        invalidPrefixes.some((prefix) => link.startsWith(prefix)) ||
+        invalidSuffixes.some((suffix) => link.endsWith(suffix))
+      )
+        continue
+
+      let standardizedLink: string
+
+      if (link.startsWith('http')) {
+        standardizedLink = link
+      } else if (link.startsWith('//')) {
+        const base = new URL(baseUrl)
+        standardizedLink = base.protocol + link
+      } else {
+        standardizedLink = new URL(link, baseUrl).href
+      }
+
+      if (
+        this.excludeDirs.some((exDir) => standardizedLink.startsWith(exDir))
+        ||
+        this.excludeGlobs.some(r => r.test(standardizedLink))
+      )
+        continue
+
+      if (link.startsWith('http')) {
+        const isAllowed = !this.preventOutside || link.startsWith(baseUrl)
+        if (isAllowed) absolutePaths.push(link)
+      } else if (link.startsWith('//')) {
+        const base = new URL(baseUrl)
+        absolutePaths.push(base.protocol + link)
+      } else {
+        const newLink = new URL(link, baseUrl).href
+        absolutePaths.push(newLink)
+      }
+    }
+
+    return Array.from(new Set(absolutePaths))
+  }
+
+  private extractMetadataFn(rawHtml: string, url: string) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const metadata: Metadata = { source: url }
+    const { document } = new JSDOM(rawHtml).window
+
+    const title = document.getElementsByTagName('title')[0]
+    if (title) {
+      metadata.title = title.textContent ?? ''
+    }
+
+    const description = document.querySelector('meta[name=description]')
+    if (description) {
+      metadata.description = description.getAttribute('content') ?? ''
+    }
+
+    const html = document.getElementsByTagName('html')[0]
+    if (html) {
+      metadata.language = html.getAttribute('lang') ?? ''
+    }
+
+    return metadata
+  }
+
+  private async getUrlAsDoc(url: string): Promise<Document | null> {
+    let res
+    try {
+      res = await this.fetchWithTimeout(url, { timeout: this.timeout })
+      res = await res.text()
+    } catch (e) {
+      return null
+    }
+
+    return {
+      pageContent: this.extractor(res),
+      metadata: this.extractMetadata(res, url),
+    }
+  }
+
+  async getChildUrlsRecursive(
+    inputUrl: string,
+    visited: Set<string> = new Set<string>(),
+    depth = 0
+  ): Promise<Document[]> {
+    if (depth >= this.maxDepth) return []
+
+    let url = inputUrl
+    if (!inputUrl.endsWith('/')) url += '/'
+
+    const isExcluded = this.excludeDirs.some((exDir) => url.startsWith(exDir)) || this.excludeGlobs.some(r => r.test(url))
+    if (isExcluded) return []
+
+    let res
+    try {
+      res = await this.fetchWithTimeout(url, { timeout: this.timeout }, true)
+      res = await res.text()
+    } catch (e) {
+      return []
+    }
+
+    const childUrls: string[] = this.getChildLinks(res, url)
+
+    const results = await Promise.all(
+      childUrls.map((childUrl) =>
+        (async () => {
+          if (visited.has(childUrl)) return null
+          visited.add(childUrl)
+
+          const childDoc = await this.getUrlAsDoc(childUrl)
+          if (!childDoc) return null
+
+          if (childUrl.endsWith('/')) {
+            const childUrlResponses = await this.getChildUrlsRecursive(
+              childUrl,
+              visited,
+              depth + 1
+            )
+            return [childDoc, ...childUrlResponses]
+          }
+
+          return [childDoc]
+        })()
+      )
+    )
+
+    return results.flat().filter((docs) => docs !== null) as Document[]
+  }
+
+  async load(): Promise<Document[]> {
+    const rootDoc = await this.getUrlAsDoc(this.url)
+    if (!rootDoc) return []
+
+    const docs = [rootDoc]
+    docs.push(
+      ...(await this.getChildUrlsRecursive(this.url, new Set([this.url])))
+    )
+    return docs
+  }
+}


### PR DESCRIPTION
1. 修复前台选择了 Jina Reader 无法递归抓取网页
2. 新增 递归抓取到的 URL 也存储数据库
3. 递归抓页面支持选择 Page Parser
4. 支持自定义 深度（最大`3`）、自定义排除 URL

![图片](https://github.com/sugarforever/chat-ollama/assets/5283258/2603be7e-858e-480b-87ce-ada749ca9697)
