### PR TITLE
fix: hljs fallback to plaintext if lang not support

### DIFF
--- a/composables/markdown.ts
+++ b/composables/markdown.ts
@@ -2,18 +2,22 @@ import MarkdownIt from "markdown-it"
 import MarkdownItAbbr from "markdown-it-abbr"
 import MarkdownItAnchor from "markdown-it-anchor"
 import MarkdownItFootnote from "markdown-it-footnote"
-import MarkdownItHighlightjs from "markdown-it-highlightjs"
 import MarkdownItSub from "markdown-it-sub"
 import MarkdownItSup from "markdown-it-sup"
 import MarkdownItTasklists from "markdown-it-task-lists"
 import MarkdownItTOC from "markdown-it-toc-done-right"
+import hljs from "highlight.js"
 
 export function useMarkdown() {
-  return new MarkdownIt()
+  return new MarkdownIt({
+    highlight(str, lang) {
+      lang = hljs.getLanguage(lang) ? lang : 'plaintext'
+      return hljs.highlight(str, { language: lang, ignoreIllegals: true }).value
+    },
+  })
     .use(MarkdownItAbbr)
     .use(MarkdownItAnchor)
     .use(MarkdownItFootnote)
-    .use(MarkdownItHighlightjs)
     .use(MarkdownItSub)
     .use(MarkdownItSup)
     .use(MarkdownItTasklists)

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "markdown-it-abbr": "^2.0.0",
     "markdown-it-anchor": "^8.6.7",
     "markdown-it-footnote": "^4.0.0",
-    "markdown-it-highlightjs": "^4.0.1",
     "markdown-it-sub": "^2.0.0",
     "markdown-it-sup": "^2.0.0",
     "markdown-it-task-lists": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,9 +107,6 @@ dependencies:
   markdown-it-footnote:
     specifier: ^4.0.0
     version: 4.0.0
-  markdown-it-highlightjs:
-    specifier: ^4.0.1
-    version: 4.0.1
   markdown-it-sub:
     specifier: ^2.0.0
     version: 2.0.0
@@ -6548,12 +6545,6 @@ packages:
 
   /markdown-it-footnote@4.0.0:
     resolution: {integrity: sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==}
-    dev: false
-
-  /markdown-it-highlightjs@4.0.1:
-    resolution: {integrity: sha512-EPXwFEN6P5nqR3G4KjT20r20xbGYKMMA/360hhSYFmeoGXTE6hsLtJAiB/8ID8slVH4CWHHEL7GX0YenyIstVQ==}
-    dependencies:
-      highlight.js: 11.9.0
     dev: false
 
   /markdown-it-sub@2.0.0:


### PR DESCRIPTION
代码块的语言如果不支持高亮则默认使用 纯文本 模式，避免报错