### PR TITLE
fix:  $fetchWithAuth has the wrong type for the DELETE method

### DIFF
--- a/composables/fetchWithAuth.ts
+++ b/composables/fetchWithAuth.ts
@@ -1,5 +1,3 @@
-import type { NitroFetchRequest, NitroFetchOptions } from 'nitropack'
-
 export const fetchWithAuth: typeof fetch = (request, opts?) => {
   const { token } = useAuth()
   return fetch(request, {
@@ -11,9 +9,9 @@ export const fetchWithAuth: typeof fetch = (request, opts?) => {
   })
 }
 
-export function $fetchWithAuth<T = unknown, R extends NitroFetchRequest = NitroFetchRequest, O extends NitroFetchOptions<R> = NitroFetchOptions<R>>(request: R, opts?: O) {
+function _fetchWithAuth(request: any, opts?: any) {
   const { token } = useAuth()
-  return $fetch<T, R>(request, {
+  return $fetch(request, {
     ...opts,
     headers: {
       ...opts?.headers,
@@ -21,3 +19,8 @@ export function $fetchWithAuth<T = unknown, R extends NitroFetchRequest = NitroF
     }
   })
 }
+
+_fetchWithAuth.raw = $fetch.raw
+_fetchWithAuth.create = $fetch.create
+
+export const $fetchWithAuth = _fetchWithAuth as typeof $fetch


### PR DESCRIPTION
如果请求方法是 DELETE ，那么该方法会拿到错误的类型

目前没有好的方法，只能使用强制转换类型