### PR TITLE
bugfix: recursive url loader should not skip on urls not trailing with slash

### DIFF
--- a/server/docstore/redis.ts
+++ b/server/docstore/redis.ts
@@ -1,61 +1,60 @@
-import { Document } from "@langchain/core/documents";
-import { BaseStoreInterface } from "@langchain/core/stores";
-import { Redis } from "ioredis";
-import { createRedisClient } from "@/server/store/redis";
+import { Document } from "@langchain/core/documents"
+import { BaseStoreInterface } from "@langchain/core/stores"
+import { Redis } from "ioredis"
+import { createRedisClient } from "@/server/store/redis"
 
-export class RedisDocstore implements BaseStoreInterface<string, Document>
-{
-  _namespace: string;
-  _client: Redis;
+export class RedisDocstore implements BaseStoreInterface<string, Document> {
+  _namespace: string
+  _client: Redis
 
   constructor(namespace: string) {
-    this._namespace = namespace;
-    this._client = createRedisClient();
+    this._namespace = namespace
+    this._client = createRedisClient()
   }
 
   serializeDocument(doc: Document): string {
-    return JSON.stringify(doc);
+    return JSON.stringify(doc)
   }
 
   deserializeDocument(jsonString: string): Document {
-    const obj = JSON.parse(jsonString);
-    return new Document(obj);
+    const obj = JSON.parse(jsonString)
+    return new Document(obj)
   }
 
   getNamespacedKey(key: string): string {
-    return `${this._namespace}:${key}`;
+    return `${this._namespace}:${key}`
   }
 
   getKeys(): Promise<string[]> {
     return new Promise((resolve, reject) => {
-      const stream = this._client.scanStream({ match: this._namespace + '*' });
+      const stream = this._client.scanStream({ match: this._namespace + '*' })
 
-      const keys: string[] = [];
+      const keys: string[] = []
       stream.on('data', (resultKeys) => {
-        keys.push(...resultKeys);
-      });
+        keys.push(...resultKeys)
+      })
 
       stream.on('end', () => {
-        resolve(keys);
-      });
+        resolve(keys)
+      })
 
       stream.on('error', (err) => {
-        reject(err);
-      });
-    });
+        reject(err)
+      })
+    })
   }
 
   addText(key: string, value: string) {
-    this._client.set(this.getNamespacedKey(key), value);
+    this._client.set(this.getNamespacedKey(key), value)
   }
 
   async search(search: string): Promise<Document> {
-    const result = await this._client.get(this.getNamespacedKey(search));
+    const result = await this._client.get(this.getNamespacedKey(search))
     if (!result) {
-      throw new Error(`ID ${search} not found.`);
+      throw new Error(`ID ${search} not found.`)
     } else {
-      const document = this.deserializeDocument(result);
-      return document;
+      const document = this.deserializeDocument(result)
+      return document
     }
   }
 
@@ -66,71 +65,71 @@ export class RedisDocstore implements BaseStoreInterface<string, Document>
    */
   async add(texts: Record<string, Document>): Promise<void> {
     for (const [key, value] of Object.entries(texts)) {
-      console.log(`Adding ${key} to the store: ${this.serializeDocument(value)}`);
+      // console.log(`Adding ${key} to the store: ${this.serializeDocument(value)}`);
     }
 
-    const keys = [...await this.getKeys()];
-    const overlapping = Object.keys(texts).filter((x) => keys.includes(x));
+    const keys = [...await this.getKeys()]
+    const overlapping = Object.keys(texts).filter((x) => keys.includes(x))
 
     if (overlapping.length > 0) {
-      throw new Error(`Tried to add ids that already exist: ${overlapping}`);
+      throw new Error(`Tried to add ids that already exist: ${overlapping}`)
     }
 
     for (const [key, value] of Object.entries(texts)) {
-      this.addText(key, this.serializeDocument(value));
+      this.addText(key, this.serializeDocument(value))
     }
   }
 
   async mget(keys: string[]): Promise<Document[]> {
     return Promise.all(keys.map((key) => {
-      const document = this.search(key);
-      return document;
-    }));
+      const document = this.search(key)
+      return document
+    }))
   }
 
   async mset(keyValuePairs: [string, Document][]): Promise<void> {
     await Promise.all(
       keyValuePairs.map(([key, value]) => this.add({ [key]: value }))
-    );
+    )
   }
 
   async mdelete(_keys: string[]): Promise<void> {
-    throw new Error("Not implemented.");
+    throw new Error("Not implemented.")
   }
 
   // eslint-disable-next-line require-yield
   async *yieldKeys(_prefix?: string): AsyncGenerator<string> {
-    throw new Error("Not implemented");
+    throw new Error("Not implemented")
   }
 
   async deleteAll(): Promise<void> {
     return new Promise((resolve, reject) => {
-      let cursor = '0';
+      let cursor = '0'
 
       const scanCallback = (err, result) => {
         if (err) {
-          reject(err);
-          return;
+          reject(err)
+          return
         }
 
-        const [nextCursor, keys] = result;
+        const [nextCursor, keys] = result
 
         // Delete keys matching the prefix
         keys.forEach((key) => {
-          this._client.del(key);
-        });
+          this._client.del(key)
+        })
 
         // If the cursor is '0', we've iterated through all keys
         if (nextCursor === '0') {
-          resolve();
+          resolve()
         } else {
           // Continue scanning with the next cursor
-          this._client.scan(nextCursor, 'MATCH', `${this._namespace}:*`, scanCallback);
+          this._client.scan(nextCursor, 'MATCH', `${this._namespace}:*`, scanCallback)
         }
-      };
+      }
 
       // Start the initial SCAN operation
-      this._client.scan(cursor, 'MATCH', `${this._namespace}:*`, scanCallback);
-    });
+      this._client.scan(cursor, 'MATCH', `${this._namespace}:*`, scanCallback)
+    })
   }
 }


### PR DESCRIPTION
#390 

LangChain的加载器 `RecursiveUrlLoader` 在基于URL递归加载时，会跳过不以 `/` 结尾的URL。

许多站点的目录级别的URL并不以 / 结尾。ChatOllama期望这类URL也被检索。