### PR TITLE
feat: add env variable to set max attached messages  #361

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,6 @@ NUXT_PUBLIC_MODEL_PROXY_ENABLED=false
 #   http://username:password@127.0.0.1:1080
 #   socks5://username:password@127.0.0.1:1080
 NUXT_MODEL_PROXY_URL=
+
+# Chat
+NUXT_PUBLIC_CHAT_MAX_ATTACHED_MESSAGES=50

--- a/components/ChatSettings.vue
+++ b/components/ChatSettings.vue
@@ -106,7 +106,7 @@ async function onReset() {
         <UFormGroup label="Attached Messages Count" name="instructionId">
           <div class="flex items-center">
             <span class="mr-2 w-6 text-primary-500">{{ state.attachedMessagesCount }}</span>
-            <URange v-model="state.attachedMessagesCount" :min="0" :max="50" size="md" />
+            <URange v-model="state.attachedMessagesCount" :min="0" :max="$config.public.chatMaxAttachedMessages" size="md" />
           </div>
         </UFormGroup>
         <template #footer>

--- a/components/settings/SettingsChatSettings.vue
+++ b/components/settings/SettingsChatSettings.vue
@@ -21,7 +21,7 @@ const model = computed({
       <UFormGroup label="Attached Message Count">
         <div class="flex items-center">
           <span class="mr-2 w-6 text-primary-500">{{ chatDefaultSettings.attachedMessagesCount }}</span>
-          <URange v-model="chatDefaultSettings.attachedMessagesCount" :min="0" :max="50" size="md" />
+          <URange v-model="chatDefaultSettings.attachedMessagesCount" :min="0" :max="$config.public.chatMaxAttachedMessages" size="md" />
         </div>
       </UFormGroup>
     </SettingsCard>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -72,6 +72,7 @@ export default defineNuxtConfig({
         }
       },
       modelProxyEnabled: false,
+      chatMaxAttachedMessages: 50,
     },
     modelProxyUrl: '',
   }


### PR DESCRIPTION
可在 .env 文件中配置 `NUXT_PUBLIC_CHAT_MAX_ATTACHED_MESSAGES` 来修改最大附加消息的长度