### PR TITLE
set Ollama num_predict to 3000

### DIFF
--- a/server/utils/models.ts
+++ b/server/utils/models.ts
@@ -109,6 +109,7 @@ export const createChatModel = (modelName: string, family: string, event: H3Even
     chat = new ChatOllama({
       baseUrl: keys.ollama.endpoint,
       model: modelName,
+      numPredict: 3000
     })
   };
 


### PR DESCRIPTION
#413 

Ollama 利用 num_predict 来限制生成的token数。目前限制为3000。目的是避免Ollama的模型无限输出。