### PR TITLE
统一模型的获取，增加 nomic-bert 提取

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
   "vue.format.wrapAttributes": "preserve-aligned",
   "html.format.wrapLineLength": 0,
   "cSpell.words": [
+    "composables",
     "dexie",
     "groq",
     "jina",

--- a/components/ChatSessionList.vue
+++ b/components/ChatSessionList.vue
@@ -10,6 +10,8 @@ const emits = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const createChatSession = useCreateChatSession()
+
 const sessionList = ref<ChatSessionInfo[]>([])
 const currentSessionId = useStorage<number>('currentSessionId', 0)
 const confirm = useDialog('confirm')

--- a/components/KnowledgeBaseForm.vue
+++ b/components/KnowledgeBaseForm.vue
@@ -16,6 +16,8 @@ const props = defineProps<{
 
 const { t } = useI18n()
 const toast = useToast()
+const { ollamaEmbeddingModels } = useModels()
+
 const state = reactive({
   files: [] as File[],
   name: props.data?.name || '',
@@ -29,14 +31,15 @@ const state = reactive({
 })
 const loading = ref(false)
 const isModify = computed(() => props.type === 'update')
-const embeddings = [
-  generateEmbeddingData('Ollama', props.embeddings.filter(e => ![...OPENAI_EMBEDDING_MODELS, ...GEMINI_EMBEDDING_MODELS].includes(e)), 'group'),
-  generateEmbeddingData('OpenAI', OPENAI_EMBEDDING_MODELS, 'group'),
-  generateEmbeddingData('Gemini', GEMINI_EMBEDDING_MODELS, 'group'),
-]
 const embeddingList = computed(() => {
   const val = state.embedding.toLowerCase()
-  return embeddings.flatMap(items => {
+  const getEmbeddingFromKnowledgeBaseList = props.embeddings.filter(e => ![...OPENAI_EMBEDDING_MODELS, ...GEMINI_EMBEDDING_MODELS].includes(e))
+  const ollamaEmbeddingList = [...new Set([...ollamaEmbeddingModels.value.map(e => e.value), ...getEmbeddingFromKnowledgeBaseList])]
+  return [
+    generateEmbeddingData('Ollama', ollamaEmbeddingList, 'group'),
+    generateEmbeddingData('OpenAI', OPENAI_EMBEDDING_MODELS, 'group'),
+    generateEmbeddingData('Gemini', GEMINI_EMBEDDING_MODELS, 'group'),
+  ].flatMap(items => {
     const arr = items.filter(el => 'slot' in el || el.value.toLowerCase().includes(val))
     return arr.length > 1 ? [arr] : []
   })

--- a/components/Models.vue
+++ b/components/Models.vue
@@ -3,8 +3,8 @@ import { computed, ref } from 'vue'
 import type { ModelItem } from '@/server/api/models/index.get'
 
 const { t } = useI18n()
+const { loadModels, models } = useModels({ forceReload: true })
 
-const models = ref<ModelItem[]>([])
 const modelRows = computed(() => {
   return models.value.map((model) => {
     return {
@@ -28,13 +28,6 @@ const columns = computed(() => {
   ]
 })
 
-const loadModels = async () => {
-  const response = await $fetchWithAuth<ModelItem[]>('/api/models/', {
-    headers: getKeysHeader()
-  })
-  models.value = response
-}
-
 const selectedRows = ref<ModelItem[]>([])
 const select = (row: ModelItem) => {
   const index = selectedRows.value.findIndex((item) => item.name === row.name)
@@ -55,10 +48,6 @@ const actions = [
     }
   }]
 ]
-
-const onModelDownloaded = () => {
-  loadModels()
-}
 
 // Modal
 const isOpen = ref(false)
@@ -87,10 +76,6 @@ const resetModal = () => {
   isOpen.value = false
 }
 
-onMounted(() => {
-  loadModels()
-})
-
 function formatFileSize(bytes?: number) {
   if (bytes === undefined) return '-'
   if (bytes === 0) return '0 Bytes'
@@ -102,7 +87,7 @@ function formatFileSize(bytes?: number) {
 </script>
 
 <template>
-  <Download @modelDownloaded="onModelDownloaded" />
+  <Download @modelDownloaded="loadModels" />
   <div class="mt-3 h-7">
     <UDropdown v-if="selectedRows.length > 0" :items="actions" :ui="{ width: 'w-36' }">
       <UButton icon="i-heroicons-chevron-down" trailing color="gray" size="xs">

--- a/components/ModelsSelectMenu.vue
+++ b/components/ModelsSelectMenu.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { type ModelInfo } from '~/utils/settings'
+import type { ModelInfo } from '~/composables/useModels'
 
 const props = withDefaults(defineProps<{
   autoDefault?: boolean,
@@ -14,6 +14,8 @@ type ModelFamilyName = string
 const value = defineModel<[ModelName, ModelFamilyName]>({ default: [] })
 const currentModel = defineModel<ModelInfo>('modelInfo')
 
+const { loadModels, chatModels } = useModels({ immediate: false })
+
 const selectValue = computed({
   get() {
     return getModelItem()
@@ -23,20 +25,20 @@ const selectValue = computed({
   }
 })
 
-const models = await loadModels()
+await loadModels()
 
 watch(value, () => {
   currentModel.value = getModelItem()
 }, { immediate: true })
 
 onMounted(() => {
-  if (props.autoDefault && [...value.value].length === 0 && models.length > 0) {
-    value.value = [models[0].value, models[0].family || '']
+  if (props.autoDefault && [...value.value].length === 0 && chatModels.value.length > 0) {
+    value.value = [chatModels.value[0].value, chatModels.value[0].family || '']
   }
 })
 
 function getModelItem() {
-  return models.find(el => {
+  return chatModels.value.find(el => {
     return el.value === value.value?.[0] && (value.value[1] === '' || value.value[1] === el.family)
   })
 }
@@ -45,7 +47,7 @@ function getModelItem() {
 <template>
   <ClientOnly>
     <USelectMenu v-model="selectValue"
-                 :options="models"
+                 :options="chatModels"
                  :size
                  placeholder="Select a model">
       <template #label>

--- a/composables/chat.ts
+++ b/composables/chat.ts
@@ -1,28 +1,33 @@
 interface ChatSessionBaseData extends Omit<ChatSession, 'id'> { }
 
-export async function createChatSession(params?: Partial<Omit<ChatSessionBaseData, 'attachedMessagesCount' | 'createTime' | 'updateTime'>>) {
-  const baseData: ChatSessionBaseData = {
-    createTime: Date.now(),
-    updateTime: Date.now(),
-    title: params?.title || '',
-    model: params?.model || chatDefaultSettings.value.model[0],
-    modelFamily: params?.modelFamily || '',
-    instructionId: params?.instructionId || 0,
-    knowledgeBaseId: params?.knowledgeBaseId || 0,
-    attachedMessagesCount: chatDefaultSettings.value.attachedMessagesCount,
-  }
+export function useCreateChatSession() {
+  const { chatModels, loadModels } = useModels({ immediate: false })
+  const { t } = useI18n()
+  const toast = useToast()
 
-  // set default model
-  const models = await loadModels()
-  if (models.length === 0) {
-    const toast = useToast()
-    toast.add({ title: 'No model found', description: 'Please download a model first.', color: 'red' })
-  } else {
-    const model = models.find(m => m.value === baseData.model) || models[0]
-    baseData.model = model.value
-    baseData.modelFamily = model.family || ''
-  }
+  return async function createChatSession(params?: Partial<Omit<ChatSessionBaseData, 'attachedMessagesCount' | 'createTime' | 'updateTime'>>) {
+    const baseData: ChatSessionBaseData = {
+      createTime: Date.now(),
+      updateTime: Date.now(),
+      title: params?.title || '',
+      model: params?.model || chatDefaultSettings.value.model[0],
+      modelFamily: params?.modelFamily || '',
+      instructionId: params?.instructionId || 0,
+      knowledgeBaseId: params?.knowledgeBaseId || 0,
+      attachedMessagesCount: chatDefaultSettings.value.attachedMessagesCount,
+    }
 
-  const id = await clientDB.chatSessions.add(baseData)
-  return { ...baseData, id, count: 0 }
+    // set default model
+    await loadModels()
+    if (chatModels.value.length === 0) {
+      toast.add({ title: t('chat.noModelFound'), description: t('chat.noModelFoundDesc'), color: 'red' })
+    } else {
+      const model = chatModels.value.find(m => m.value === baseData.model) || chatModels.value[0]
+      baseData.model = model.value
+      baseData.modelFamily = model.family || ''
+    }
+
+    const id = await clientDB.chatSessions.add(baseData)
+    return { ...baseData, id, count: 0 }
+  }
 }

--- a/composables/useModels.ts
+++ b/composables/useModels.ts
@@ -1,0 +1,61 @@
+import { useSessionStorage } from '@vueuse/core'
+import type { ModelItem } from '~/server/api/models/index.get'
+
+export interface ModelInfo {
+  label: string
+  value: string
+  family?: string
+}
+
+interface Options {
+  /** default `false` */
+  forceReload?: boolean
+  /** default `true` */
+  immediate?: boolean
+}
+
+export function useModels(options?: Options) {
+  const opts = Object.assign({ immediate: true, forceReload: false }, options)
+  const models = useSessionStorage<ModelItem[]>('models', [])
+  const loading = ref(false)
+  const OLLAMA_EMBEDDING_FAMILY_LIST = ['nomic-bert']
+
+  const chatModels = computed(() => {
+    return models.value
+      .filter(el => !OLLAMA_EMBEDDING_FAMILY_LIST.includes(el?.details?.family))
+      .map(el => ({
+        label: `${el?.details?.family === "Azure OpenAI" ? `Azure ${el.name}` : el.name}`,
+        value: el.name!,
+        family: el?.details?.family,
+      }))
+  })
+
+  const ollamaEmbeddingModels = computed(() => {
+    return models.value
+      .filter(el => OLLAMA_EMBEDDING_FAMILY_LIST.includes(el?.details?.family))
+      .map(el => ({ label: el.name!, value: el.name!, family: el?.details?.family }))
+  })
+
+  let controller: AbortController | undefined
+
+  async function loadModels() {
+    controller?.abort()
+
+    loading.value = true
+    controller = new AbortController()
+    if (models.value.length === 0 || opts.forceReload) {
+      const response = await $fetchWithAuth('/api/models/', {
+        headers: getKeysHeader(),
+        signal: controller.signal,
+      })
+      models.value = response as ModelItem[]
+    }
+    loading.value = false
+    return models.value
+  }
+
+  if (opts?.immediate)
+    loadModels()
+
+  return { models, chatModels, ollamaEmbeddingModels, loadModels, loading }
+}

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -83,7 +83,9 @@
     "responseException": "Oops! Response Exception",
     "selectKB": "Select a knowledge base",
     "selectInstruction": "Select an Instruction",
-    "resend": "Resend"
+    "resend": "Resend",
+    "noModelFound": "No model found",
+    "noModelFoundDesc": "Please download a model first."
   },
   "settings": {
     "ollamaServer": "Ollama Server",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -83,7 +83,9 @@
     "responseException": "哎呀！响应异常",
     "selectKB": "选择一个知识库",
     "selectInstruction": "选择指令",
-    "resend": "重发"
+    "resend": "重发",
+    "noModelFound": "没有找到模型",
+    "noModelFoundDesc": "请先在模型管理页面下载模型"
   },
   "settings": {
     "ollamaServer": "Ollama 服务",

--- a/pages/knowledgebases/index.vue
+++ b/pages/knowledgebases/index.vue
@@ -10,6 +10,7 @@ const modal = useModal()
 const confirm = useDialog('confirm')
 const toast = useToast()
 const currentSessionId = useStorage<number>('currentSessionId', 0)
+const createChatSession = useCreateChatSession()
 
 const { data, refresh } = await useFetch('/api/knowledgebases', {
   headers: {

--- a/utils/settings.ts
+++ b/utils/settings.ts
@@ -55,28 +55,6 @@ export const loadOllamaInstructions = async () => {
   }
 }
 
-export interface ModelInfo {
-  label: string
-  value: string
-  family?: string
-}
-
-export async function loadModels(): Promise<ModelInfo[]> {
-  const response = await $fetchWithAuth('/api/models/', {
-    headers: getKeysHeader(),
-  })
-  return response
-    // filter out nomic-bert family models，as they as embedding models do not support chat apparently.
-    .filter(el => el?.details?.family !== 'nomic-bert')
-    .map(el => {
-      return {
-        label: `${el?.details?.family === "Azure OpenAI" ? `Azure ${el.name}` : el.name}`,
-        value: el.name!,
-        family: el?.details?.family,
-      }
-    })
-}
-
 export async function loadKnowledgeBases() {
   const response = await $fetchWithAuth('/api/knowledgebases/').catch(() => null)
   return (response?.knowledgeBases || []) as KnowledgeBase[]


### PR DESCRIPTION
- 前端统一模型的处理，不再多次请求模型（数据缓存在 sessionStorage 中，且只有每次切换到 Models 页面才会重新获取最新的模型列表）
- 创建知识库中的模型下拉列表默认会从模型列表中提取 nomic-bert 家族的模型作为文本嵌入模型

#400 