### PR TITLE
feat: use Peanut Shell API as local reranking service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ MILVUS_URL=http://localhost:19530
 
 # Cohere API Key - Reranking
 COHERE_API_KEY=
+COHERE_MODEL=
+COHERE_BASE_URL=
 
 # Super admin name
 SUPER_ADMIN_NAME=

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -92,7 +92,7 @@ export default defineNuxtConfig({
       chatMaxAttachedMessages: 50,
       appName: APP_NAME,
     },
-    modelProxyUrl: '',
+    modelProxyUrl: ''
   },
   i18n: {
     //Asynchronous call, on-demand loading

--- a/server/api/models/chat/index.post.ts
+++ b/server/api/models/chat/index.post.ts
@@ -2,7 +2,8 @@ import { Readable } from 'stream'
 import { formatDocumentsAsString } from "langchain/util/document"
 import { PromptTemplate } from "@langchain/core/prompts"
 import { RunnableSequence } from "@langchain/core/runnables"
-import { CohereRerank } from "@langchain/cohere"
+// import { CohereRerank } from "@langchain/cohere"
+import { CohereRerank } from "@/server/rerank/cohere"
 import { setEventStreamResponse } from '@/server/utils'
 import { BaseRetriever } from "@langchain/core/retrievers"
 import prisma from "@/server/utils/prisma"
@@ -75,12 +76,15 @@ export default defineEventHandler(async (event) => {
 
     let rerankedDocuments = relevant_docs
 
-    if (process.env.COHERE_API_KEY) {
-      const cohereRerank = new CohereRerank({
+    if ((process.env.COHERE_API_KEY || process.env.COHERE_BASE_URL) && process.env.COHERE_MODEL) {
+      const options = {
         apiKey: process.env.COHERE_API_KEY,
-        model: "rerank-multilingual-v2.0",
+        baseUrl: process.env.COHERE_BASE_URL,
+        model: process.env.COHERE_MODEL,
         topN: 4
-      })
+      }
+      console.log("Cohere Rerank Options: ", options)
+      const cohereRerank = new CohereRerank(options)
       rerankedDocuments = await cohereRerank.compressDocuments(relevant_docs, query)
       console.log("Cohere reranked documents: ", rerankedDocuments)
     }

--- a/server/rerank/cohere.ts
+++ b/server/rerank/cohere.ts
@@ -1,0 +1,136 @@
+import { DocumentInterface } from "@langchain/core/documents"
+import { BaseDocumentCompressor } from "@langchain/core/retrievers/document_compressors"
+import { getEnvironmentVariable } from "@langchain/core/utils/env"
+import { CohereClient } from "cohere-ai"
+
+export interface CohereRerankArgs {
+  /**
+   * The API key to use.
+   * @default {process.env.COHERE_API_KEY}
+   */
+  apiKey?: string
+  /**
+   * The name of the model to use.
+   * @default {"rerank-english-v2.0"}
+   */
+  model?: string
+  /**
+   * How many documents to return.
+   * @default {3}
+   */
+  topN?: number
+  /**
+   * The maximum number of chunks per document.
+   */
+  maxChunksPerDoc?: number
+  /**
+   * Base URL for the Cohere API.
+   */
+  baseUrl?: string
+}
+
+/**
+ * Document compressor that uses `Cohere Rerank API`.
+ */
+export class CohereRerank extends BaseDocumentCompressor {
+  model = "rerank-english-v2.0";
+
+  topN = 3;
+
+  client: CohereClient
+
+  maxChunksPerDoc: number | undefined
+
+  constructor(fields?: CohereRerankArgs) {
+    super()
+    const token = fields?.apiKey ?? getEnvironmentVariable("COHERE_API_KEY")
+    if (!token) {
+      throw new Error("No API key provided for CohereRerank.")
+    }
+
+    const cohereClientOptions = { token }
+    if (fields?.baseUrl) {
+      cohereClientOptions.environment = fields.baseUrl
+    }
+
+    this.client = new CohereClient(cohereClientOptions)
+    this.model = fields?.model ?? this.model
+    this.topN = fields?.topN ?? this.topN
+    this.maxChunksPerDoc = fields?.maxChunksPerDoc
+  }
+
+  /**
+   * Compress documents using Cohere's rerank API.
+   *
+   * @param {Array<DocumentInterface>} documents A sequence of documents to compress.
+   * @param {string} query The query to use for compressing the documents.
+   *
+   * @returns {Promise<Array<DocumentInterface>>} A sequence of compressed documents.
+   */
+  async compressDocuments(
+    documents: Array<DocumentInterface>,
+    query: string
+  ): Promise<Array<DocumentInterface>> {
+    const _docs = documents.map((doc) => doc.pageContent)
+    const { results } = await this.client.rerank({
+      model: this.model,
+      query,
+      documents: _docs,
+      topN: this.topN,
+      maxChunksPerDoc: this.maxChunksPerDoc,
+    })
+    const finalResults: Array<DocumentInterface> = []
+    for (let i = 0; i < results.length; i += 1) {
+      const result = results[i]
+      const doc = documents[result.index]
+      doc.metadata.relevanceScore = result.relevanceScore
+      finalResults.push(doc)
+    }
+    return finalResults
+  }
+
+  /**
+   * Returns an ordered list of documents ordered by their relevance to the provided query.
+   *
+   * @param {Array<DocumentInterface | string | Record<string, string>>} documents A list of documents as strings, DocumentInterfaces or objects with a `pageContent` key.
+   * @param {string} query The query to use for reranking the documents.
+   * @param options
+   * @param {string} options.model The name of the model to use.
+   * @param {number} options.topN How many documents to return.
+   * @param {number} options.maxChunksPerDoc The maximum number of chunks per document.
+   *
+   * @returns {Promise<Array<{ index: number; relevanceScore: number }>>} An ordered list of documents with relevance scores.
+   */
+  async rerank(
+    documents: Array<DocumentInterface | string | Record<string, string>>,
+    query: string,
+    options?: {
+      model?: string
+      topN?: number
+      maxChunksPerDoc?: number
+    }
+  ): Promise<Array<{ index: number; relevanceScore: number }>> {
+    const docs = documents.map((doc) => {
+      if (typeof doc === "string") {
+        return doc
+      }
+      return doc.pageContent
+    })
+    const model = options?.model ?? this.model
+    const topN = options?.topN ?? this.topN
+    const maxChunksPerDoc = options?.maxChunksPerDoc ?? this.maxChunksPerDoc
+    const { results } = await this.client.rerank({
+      model,
+      query,
+      documents: docs,
+      topN,
+      maxChunksPerDoc,
+    })
+
+    const resultObjects = results.map((result) => ({
+      index: result.index,
+      relevanceScore: result.relevanceScore,
+    }))
+    return resultObjects
+  }
+}


### PR DESCRIPTION
Use Peanut Shell API as the local reranking service, which is alternative to Cohere rerank API.

https://github.com/sugarforever/peanut-shell