### PR TITLE
feat: gpt-4o support and peanut-shell integration

### DIFF
--- a/config/models.ts
+++ b/config/models.ts
@@ -11,7 +11,8 @@ export const OPENAI_GPT_MODELS = [
   "gpt-3.5-turbo",
   "gpt-4",
   "gpt-4-32k",
-  "gpt-4-turbo-preview"
+  "gpt-4-turbo-preview",
+  "gpt-4o"
 ]
 
 export const AZURE_OPENAI_GPT_MODELS = [

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,9 @@ services:
       - CHROMADB_URL=http://chromadb:8000
       - DATABASE_URL=file:/app/sqlite/chatollama.sqlite
       - REDIS_HOST=redis
+      - COHERE_API_KEY=xxxxx
+      - COHERE_MODEL=ms-marco-MiniLM-L-6-v2
+      - COHERE_BASE_URL=http://peanutshell:8888/v1
     image: 0001coder/chatollama:latest
     ports:
       - "3000:3000"
@@ -27,6 +30,15 @@ services:
     volumes:
       - redis_data:/data
 
+  peanutshell:
+    image: ghcr.io/sugarforever/peanut-shell:latest
+    pull_policy: always
+    ports:
+      - "8888:8000"
+    volumes:
+      - hf_data:/root/.cache
+
 volumes:
   chromadb_data:
   redis_data:
+  hf_data:


### PR DESCRIPTION
1. OpenAI new model support - `gpt-4o`
2. Add docker compose service for `Peanut Shell` for local reranking