### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
       - "8000:8000"
     restart: always
     volumes:
-      - chromadb_data:/chroma/.chroma/index
+      - chromadb_data:/chroma/chroma
 
   chatollama:
     environment:


### PR DESCRIPTION
 #460 

This is a Chroma Path issue. You can start with the YAML file, but you might need to delete the entire volume. However, this would provide a permanent solution. The reason you can see the knowledge base on the webpage is that the data in the webpage's SQLite database is still there.

<img width="1206" alt="image" src="https://github.com/sugarforever/chat-ollama/assets/151395340/86bb864a-5544-469a-8ae7-a134148321a2">

Alternatively, you can try setting `PERSIST_DIRECTORY=${PERSIST_DIRECTORY:-/chroma/chroma}` in the YAML files.

For more detailed settings, please visit [this link](https://github.com/chroma-core/chroma/blob/main/docker-compose.yml).

Mention that I used the former method to solve the issue.