### PR TITLE
Update docker-compose_gpu.yaml

### DIFF
--- a/docker-compose_gpu.yaml
+++ b/docker-compose_gpu.yaml
@@ -1,4 +1,4 @@
-version: '3.1'
+# version: '3.1'
 
 services:
   ollama:
@@ -43,5 +43,6 @@ services:
       - redis_data:/data
 
 volumes:
+  redis_data:
   chromadb_data:
   ollama_data:


### PR DESCRIPTION
Fits dockercompose_gpu.yaml with latest docker-engine, avoid following error :


```
WARN[0000] /path_to_chat_ollama/chat-ollama/docker-compose_gpu.yaml: `version` is obsolete 
service "redis" refers to undefined volume redis_data: invalid compose project
```
