### PR TITLE
fix: custom models may not load correctly

### DIFF
--- a/server/api/models/index.get.ts
+++ b/server/api/models/index.get.ts
@@ -127,8 +127,9 @@ export default defineEventHandler(async (event) => {
           // Only attempt API call if modelsEndpoint is provided
           if (item.modelsEndpoint) {
             const endpointWithSlash = item.endpoint.endsWith('/') ? item.endpoint : item.endpoint + '/'
-            const modelsEndpoint = item.modelsEndpoint.endsWith('/') ? item.modelsEndpoint.substring(1) : item.modelsEndpoint
+            const modelsEndpoint = item.modelsEndpoint.startsWith('/') ? item.modelsEndpoint.substring(1) : item.modelsEndpoint
             const modelsUrl = new URL(modelsEndpoint, endpointWithSlash).toString()
+            console.log(`Fetching models from ${modelsUrl}`)
             const response = await fetch(modelsUrl, {
               headers: {
                 'Authorization': `Bearer ${item.key}`,

--- a/server/api/models/index.get.ts
+++ b/server/api/models/index.get.ts
@@ -127,8 +127,8 @@ export default defineEventHandler(async (event) => {
           // Only attempt API call if modelsEndpoint is provided
           if (item.modelsEndpoint) {
             const endpointWithSlash = item.endpoint.endsWith('/') ? item.endpoint : item.endpoint + '/'
-            const modelsUrl = new URL(item.modelsEndpoint, endpointWithSlash).toString()
-            console.log(`Fetching models from ${modelsUrl}`)
+            const modelsEndpoint = item.modelsEndpoint.endsWith('/') ? item.modelsEndpoint.substring(1) : item.modelsEndpoint
+            const modelsUrl = new URL(modelsEndpoint, endpointWithSlash).toString()
             const response = await fetch(modelsUrl, {
               headers: {
                 'Authorization': `Bearer ${item.key}`,
@@ -137,7 +137,7 @@ export default defineEventHandler(async (event) => {
 
             if (response.ok) {
               const data: ModelApiResponse = await response.json()
-              console.log(`${item.name} models:`, data)
+              console.log(`${item.name} models:`, data.data.map(d => d.id || d.name))
               data.data.forEach(model => {
                 models.push({
                   name: model.id || model.name,
@@ -147,6 +147,8 @@ export default defineEventHandler(async (event) => {
                 })
               })
               return // Skip the fallback if API call succeeds
+            } else {
+              console.error(`Failed to fetch models for custom endpoint ${item.name}:`, response)
             }
           }
         } catch (error) {

--- a/server/middleware/keys.ts
+++ b/server/middleware/keys.ts
@@ -42,6 +42,7 @@ export interface ContextKeys {
     aiType: Exclude<keyof ContextKeys, 'custom' | 'moonshot' | 'ollama'>
     key: string
     endpoint: string
+    modelsEndpoint: string | undefined
     proxy: boolean
     models: string[]
   }>


### PR DESCRIPTION
The construction of the models endpoint URL may cause the /v1/ section missing.