### PR TITLE
fix: the custom service is not saved

### DIFF
--- a/components/settings/CustomServerForm.vue
+++ b/components/settings/CustomServerForm.vue
@@ -27,22 +27,24 @@ const defaultModelsMap: Record<ContextKeys['custom'][number]['aiType'], string[]
 const defaultState: ContextKeys['custom'][number] = { name: '', aiType: 'openai', endpoint: '', key: '', proxy: false, models: [] }
 const defaultAiType = props.value.aiType || aiTypes[0].value
 const state = reactive(Object.assign({}, defaultState, props.value, {
-  aiType: defaultAiType,
-  models: props.value.models.length === 0 ? defaultModelsMap[defaultAiType] : props.value.models,
+  aiType: defaultAiType
 }))
 const modelName = ref('')
 const schema = computed(() => {
   return object({
+    name: string().required(t('global.required')),
     aiType: string().required(t('global.required')),
     endpoint: string().url(t('global.invalidUrl')).required(t('global.required')),
     key: string().required(t('global.required')),
-    models: array().min(1, t('global.required')),
     modelsEndpoint: string(),
+    proxy: string().optional(),
   })
 })
 
 watch(() => state.aiType, (type) => {
-  state.models = defaultModelsMap[type] || []
+  if (type !== 'openai') {
+    state.models = defaultModelsMap[type] || []
+  }
 })
 
 function onSubmit() {

--- a/server/api/models/index.get.ts
+++ b/server/api/models/index.get.ts
@@ -125,32 +125,32 @@ export default defineEventHandler(async (event) => {
       if (MODEL_FAMILIES.hasOwnProperty(item.aiType) && item.name && item.endpoint && item.key) {
         try {
           // Only attempt API call if modelsEndpoint is provided
-          if (item.modelsEndpoint) {
-            const endpointWithSlash = item.endpoint.endsWith('/') ? item.endpoint : item.endpoint + '/'
-            const modelsEndpoint = item.modelsEndpoint.startsWith('/') ? item.modelsEndpoint.substring(1) : item.modelsEndpoint
-            const modelsUrl = new URL(modelsEndpoint, endpointWithSlash).toString()
-            console.log(`Fetching models from ${modelsUrl}`)
-            const response = await fetch(modelsUrl, {
-              headers: {
-                'Authorization': `Bearer ${item.key}`,
-              }
-            })
+          const modelsEndpoint = item.modelsEndpoint || "/models"
+          const endpointWithSlash = item.endpoint.endsWith('/') ? item.endpoint : item.endpoint + '/'
 
-            if (response.ok) {
-              const data: ModelApiResponse = await response.json()
-              console.log(`${item.name} models:`, data.data.map(d => d.id || d.name))
-              data.data.forEach(model => {
-                models.push({
-                  name: model.id || model.name,
-                  details: {
-                    family: item.name
-                  }
-                })
-              })
-              return // Skip the fallback if API call succeeds
-            } else {
-              console.error(`Failed to fetch models for custom endpoint ${item.name}:`, response)
+          const normalizedModelsEndpoint = modelsEndpoint.startsWith('/') ? modelsEndpoint.substring(1) : modelsEndpoint
+          const modelsUrl = new URL(normalizedModelsEndpoint, endpointWithSlash).toString()
+          console.log(`Fetching models from ${modelsUrl}`)
+          const response = await fetch(modelsUrl, {
+            headers: {
+              'Authorization': `Bearer ${item.key}`,
             }
+          })
+
+          if (response.ok) {
+            const data: ModelApiResponse = await response.json()
+            console.log(`${item.name} models:`, data.data.map(d => d.id || d.name))
+            data.data.forEach(model => {
+              models.push({
+                name: model.id || model.name,
+                details: {
+                  family: item.name
+                }
+              })
+            })
+            return // Skip the fallback if API call succeeds
+          } else {
+            console.error(`Failed to fetch models for custom endpoint ${item.name}:`, response)
           }
         } catch (error) {
           console.error(`Failed to fetch models for custom endpoint ${item.name}:`, error)


### PR DESCRIPTION
The custom service can't be saved with OpenAI type because of the scheme definition that requires at least 1 model available. But the models list is retrieved from OpenAI model list, not the custom service provider itself. In this case, when users haven't configured OpenAI API key, they won't have a valid OpenAI model list, then the custom service creation will fail on the models validation, and not be able to get saved.

Removed the constraint on it for now.