### PR TITLE
feat: implement dynamic chat session routing with /chat/{session-id}

### DIFF
--- a/components/ModelsMultiSelectMenu.vue
+++ b/components/ModelsMultiSelectMenu.vue
@@ -20,7 +20,12 @@ const { chatModels, loadModels } = useModels()
 
 // Ensure models are loaded when component mounts
 onMounted(async () => {
-  await loadModels()
+  try {
+    await loadModels()
+  } catch (error) {
+    console.warn('Failed to load models in ModelsMultiSelectMenu:', error)
+    // Continue without models - the component should handle empty models gracefully
+  }
 })
 
 const uiMenu = {

--- a/components/ModelsSelectMenu.vue
+++ b/components/ModelsSelectMenu.vue
@@ -27,7 +27,12 @@ const selectValue = computed({
   }
 })
 
-await loadModels()
+try {
+  await loadModels()
+} catch (error) {
+  console.warn('Failed to load models in ModelsSelectMenu:', error)
+  // Continue without models - the component should handle empty models gracefully
+}
 
 watch(value, () => {
   currentModel.value = getModelItem()

--- a/components/settings/SettingsServers.vue
+++ b/components/settings/SettingsServers.vue
@@ -116,7 +116,12 @@ const onSubmit = async () => {
     const key = keyPaths.join('.') as keyof typeof state
     return key in state ? state[key] : value
   })
-  loadModels()
+  
+  try {
+    loadModels()
+  } catch (error) {
+    console.warn('Failed to reload models in SettingsServers:', error)
+  }
 
   toast.add({ title: t(`settings.setSuccessfully`), color: 'green' })
 }
@@ -149,7 +154,13 @@ function onUpdateCustomServer(data: ContextKeys['custom'][number]) {
   const index = state.custom.findIndex(el => el.name === currentCustomServer.value!.name)
   state.custom[index] = data
   keysStore.value.custom.splice(index, 1, data)
-  loadModels()
+  
+  try {
+    loadModels()
+  } catch (error) {
+    console.warn('Failed to reload models in SettingsServers:', error)
+  }
+  
   toast.add({ title: t(`settings.setSuccessfully`), color: 'green' })
 }
 
@@ -158,7 +169,12 @@ function onRemoveCustomServer() {
   state.custom.splice(index, 1)
   keysStore.value.custom.splice(index, 1)
   currentLLM.value = LLMList.value[0].key
-  loadModels()
+  
+  try {
+    loadModels()
+  } catch (error) {
+    console.warn('Failed to reload models in SettingsServers:', error)
+  }
 }
 
 const checkHost = (key: keyof typeof state, title: string) => {

--- a/composables/useCreateChatSession.ts
+++ b/composables/useCreateChatSession.ts
@@ -18,13 +18,19 @@ export function useCreateChatSession() {
     }
 
     // set default model
-    await loadModels()
-    if (chatModels.value.length === 0) {
-      toast.add({ title: t('chat.noModelFound'), description: t('chat.noModelFoundDesc'), color: 'red' })
-      baseData.models = undefined
-    } else {
-      const availableModels = baseData.models?.filter(m => chatModels.value.some(cm => cm.value === m))
-      baseData.models = availableModels
+    try {
+      await loadModels()
+      if (chatModels.value.length === 0) {
+        toast.add({ title: t('chat.noModelFound'), description: t('chat.noModelFoundDesc'), color: 'red' })
+        baseData.models = undefined
+      } else {
+        const availableModels = baseData.models?.filter(m => chatModels.value.some(cm => cm.value === m))
+        baseData.models = availableModels
+      }
+    } catch (error) {
+      console.warn('Failed to load models during session creation:', error)
+      // Continue with session creation even if models fail to load
+      baseData.models = baseData.models || []
     }
 
     const id = await clientDB.chatSessions.add(baseData)

--- a/composables/useMenus.ts
+++ b/composables/useMenus.ts
@@ -11,7 +11,6 @@ export function useMenus() {
         { label: t('menu.knowledgeBases'), icon: 'i-heroicons-book-open', to: '/knowledgebases' },
         { label: t('menu.chat'), icon: 'i-iconoir-chat-lines', to: '/chat' },
         { label: t('menu.realtime'), icon: 'i-iconoir-microphone', to: '/realtime' },
-        { label: t('menu.playground'), icon: 'i-heroicons-beaker', to: '/playground' },
         { label: t('menu.settings'), icon: 'i-heroicons-cog-6-tooth', to: '/settings' }
     ])
 }

--- a/pages/chat/[sessionId].vue
+++ b/pages/chat/[sessionId].vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import type { ComponentInstance } from 'vue'
+import ChatSessionList from '~/components/ChatSessionList.vue'
+import Chat from '~/components/Chat.vue'
+import type { ChatMessage } from '@/types/chat'
+
+export interface ChatSessionSettings extends Partial<Omit<ChatSession, 'id' | 'createTime'>> { }
+
+const { t } = useI18n()
+const route = useRoute()
+const router = useRouter()
+const chatSessionListRef = shallowRef<ComponentInstance<typeof ChatSessionList>>()
+const chatRef = shallowRef<ComponentInstance<typeof Chat>>()
+const slideover = useSlideover()
+const { isMobile } = useMediaBreakpoints()
+
+// Get sessionId from route params
+const sessionId = ref(Number(route.params.sessionId) || 0)
+const latestMessageId = ref(0)
+const isSessionListVisible = ref(true)
+
+// Watch for route changes
+watch(() => route.params.sessionId, (newSessionId) => {
+  sessionId.value = Number(newSessionId) || 0
+})
+
+watch(isMobile, val => {
+  if (!val) {
+    slideover.close()
+  }
+})
+
+function onChangeSettings(data: ChatSessionSettings) {
+  chatSessionListRef.value?.updateSessionInfo({ ...data, forceUpdateTitle: true })
+}
+
+function onMessage(data: ChatMessage | null) {
+  // remove a message if it's null
+  if (data === null) {
+    return
+  }
+
+  const content = typeof data.content === 'string' ? data.content : 'New message'
+  chatSessionListRef.value?.updateSessionInfo({
+    title: content.slice(0, 20),
+    updateTime: data.endTime || data.startTime,
+  })
+  if (latestMessageId.value !== data.id) {
+    latestMessageId.value = data.id!
+  }
+}
+
+function onNewChat() {
+  chatSessionListRef.value?.createChat()
+}
+
+async function onChangeChatSession(id: number) {
+  // Navigate to the new session URL
+  await router.push(`/chat/${id}`)
+}
+
+function onOpenSideMenu() {
+  slideover.open(ChatSessionList, {
+    ref: chatSessionListRef,
+    onSelect: onChangeChatSession,
+    onClosePanel: () => {
+      slideover.close()
+    },
+    side: 'left',
+    preventClose: true,
+  })
+}
+
+function toggleSidebar() {
+  isSessionListVisible.value = !isSessionListVisible.value
+}
+
+provide('isSessionListVisible', isSessionListVisible)
+</script>
+
+<template>
+  <div class="h-full flex" style="--chat-side-width:280px">
+    <ClientOnly>
+      <ChatSessionList ref="chatSessionListRef"
+                       class="shrink-0 w-[var(--chat-side-width)] hidden md:block transition-all duration-300 border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
+                       :class="{ 'md:!hidden': !isSessionListVisible }"
+                       @select="onChangeChatSession" />
+    </ClientOnly>
+    <ClientOnly>
+      <Chat ref="chatRef" v-if="sessionId > 0"
+            class="flex-1 min-w-0 bg-white dark:bg-gray-800"
+            :session-id="sessionId"
+            @change-settings="onChangeSettings"
+            @message="onMessage"
+            @toggle-sidebar="toggleSidebar">
+        <template #left-menu-btn>
+          <UButton :icon="isSessionListVisible ? 'i-material-symbols-lists-rounded' : 'i-heroicons-chevron-double-right'" 
+                   color="gray" 
+                   variant="ghost"
+                   class="mr-4 md:hidden" 
+                   :class="{ 'rotate-180': isSessionListVisible }" 
+                   @click="onOpenSideMenu">
+          </UButton>
+        </template>
+      </Chat>
+      <div v-else class="flex-1 flex flex-col justify-center items-center p-8 bg-white dark:bg-gray-800">
+        <div class="text-center space-y-4">
+          <div class="w-16 h-16 mx-auto bg-gray-100 dark:bg-gray-700 rounded-full flex items-center justify-center">
+            <Icon name="i-iconoir-chat-lines" class="w-8 h-8 text-gray-400" />
+          </div>
+          <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100">{{ t("chat.welcome") || "Welcome to Chat" }}</h2>
+          <p class="text-gray-600 dark:text-gray-400 max-w-md">{{ t("chat.welcomeMessage") || "Start a new conversation to begin chatting with your AI assistant." }}</p>
+          <UButton icon="i-material-symbols-add" 
+                   color="primary" 
+                   size="lg"
+                   @click="onNewChat">
+            {{ t("chat.newChat") }}
+          </UButton>
+        </div>
+      </div>
+    </ClientOnly>
+  </div>
+</template>

--- a/pages/chat/index.vue
+++ b/pages/chat/index.vue
@@ -1,112 +1,39 @@
 <script setup lang="ts">
-import type { ComponentInstance } from 'vue'
-import ChatSessionList from '~/components/ChatSessionList.vue'
-import Chat from '~/components/Chat.vue'
-import type { ChatMessage } from '@/types/chat'
+import { useStorage } from '@vueuse/core'
 
-export interface ChatSessionSettings extends Partial<Omit<ChatSession, 'id' | 'createTime'>> { }
+// Redirect to the dynamic route structure
+const router = useRouter()
 
-const { t } = useI18n()
-const chatSessionListRef = shallowRef<ComponentInstance<typeof ChatSessionList>>()
-const chatRef = shallowRef<ComponentInstance<typeof Chat>>()
-const slideover = useSlideover()
-const { isMobile } = useMediaBreakpoints()
-
-const sessionId = ref(0)
-const latestMessageId = ref(0)
-const isSessionListVisible = ref(true)
-
-watch(isMobile, val => {
-  if (!val) {
-    slideover.close()
+// Redirect /chat to /chat/0 (or to first available session)
+onMounted(async () => {
+  try {
+    // Try to get the current session or redirect to empty state
+    const currentSessionId = useStorage<number>('currentSessionId', 0)
+    
+    if (currentSessionId.value > 0) {
+      // Verify session exists
+      const session = await clientDB.chatSessions.get(currentSessionId.value)
+      if (session) {
+        await router.replace(`/chat/${currentSessionId.value}`)
+        return
+      }
+    }
+    
+    // No valid session, redirect to empty chat
+    await router.replace('/chat/0')
+  } catch (error) {
+    console.error('Error during chat redirect:', error)
+    // Fallback to empty chat
+    await router.replace('/chat/0')
   }
 })
-
-function onChangeSettings(data: ChatSessionSettings) {
-  chatSessionListRef.value?.updateSessionInfo({ ...data, forceUpdateTitle: true })
-}
-
-function onMessage(data: ChatMessage | null) {
-  // remove a message if it's null
-  if (data === null) {
-    return
-  }
-
-  const content = typeof data.content === 'string' ? data.content : 'New message'
-  chatSessionListRef.value?.updateSessionInfo({
-    title: content.slice(0, 20),
-    updateTime: data.endTime || data.startTime,
-  })
-  if (latestMessageId.value !== data.id) {
-    latestMessageId.value = data.id!
-  }
-}
-
-function onNewChat() {
-  chatSessionListRef.value?.createChat()
-}
-
-async function onChangeChatSession(id: number) {
-  sessionId.value = id
-}
-
-function onOpenSideMenu() {
-  slideover.open(ChatSessionList, {
-    ref: chatSessionListRef,
-    onSelect: onChangeChatSession,
-    onClosePanel: () => {
-      slideover.close()
-    },
-    side: 'left',
-    preventClose: true,
-  })
-}
-
-function toggleSidebar() {
-  isSessionListVisible.value = !isSessionListVisible.value
-}
-
-provide('isSessionListVisible', isSessionListVisible)
 </script>
 
 <template>
-  <div class="h-full flex" style="--chat-side-width:280px">
-    <ClientOnly>
-      <ChatSessionList ref="chatSessionListRef"
-                       class="shrink-0 w-[var(--chat-side-width)] hidden md:block transition-all duration-300 border-r border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
-                       :class="{ 'md:!hidden': !isSessionListVisible }"
-                       @select="onChangeChatSession" />
-    </ClientOnly>
-    <Chat ref="chatRef" v-if="sessionId > 0"
-          class="flex-1 min-w-0 bg-white dark:bg-gray-800"
-          :session-id="sessionId"
-          @change-settings="onChangeSettings"
-          @message="onMessage"
-          @toggle-sidebar="toggleSidebar">
-      <template #left-menu-btn>
-        <UButton :icon="isSessionListVisible ? 'i-material-symbols-lists-rounded' : 'i-heroicons-chevron-double-right'" 
-                 color="gray" 
-                 variant="ghost"
-                 class="mr-4 md:hidden" 
-                 :class="{ 'rotate-180': isSessionListVisible }" 
-                 @click="onOpenSideMenu">
-        </UButton>
-      </template>
-    </Chat>
-    <div v-else class="flex-1 flex flex-col justify-center items-center p-8 bg-white dark:bg-gray-800">
-      <div class="text-center space-y-4">
-        <div class="w-16 h-16 mx-auto bg-gray-100 dark:bg-gray-700 rounded-full flex items-center justify-center">
-          <Icon name="i-iconoir-chat-lines" class="w-8 h-8 text-gray-400" />
-        </div>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100">{{ t("chat.welcome") || "Welcome to Chat" }}</h2>
-        <p class="text-gray-600 dark:text-gray-400 max-w-md">{{ t("chat.welcomeMessage") || "Start a new conversation to begin chatting with your AI assistant." }}</p>
-        <UButton icon="i-material-symbols-add" 
-                 color="primary" 
-                 size="lg"
-                 @click="onNewChat">
-          {{ t("chat.newChat") }}
-        </UButton>
-      </div>
+  <div class="h-full flex items-center justify-center">
+    <div class="text-center space-y-4">
+      <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mx-auto"></div>
+      <p class="text-gray-600 dark:text-gray-400">Redirecting...</p>
     </div>
   </div>
 </template>


### PR DESCRIPTION
- Add dynamic routing for individual chat sessions on /chat/{session-id} URLs
- Create new [sessionId].vue page for handling session-specific routes
- Update ChatSessionList to navigate using new URL structure
- Modify session creation and selection to use router navigation
- Add proper error handling for model loading during navigation
- Fix AbortError handling in useModels for graceful request cancellation
- Improve concurrent model loading with better timeout and caching logic
- Remove playground route reference from navigation menu
- Add SSR compatibility with ClientOnly wrapper for Chat component

🤖 Generated with [Claude Code](https://claude.ai/code)